### PR TITLE
feat: Cinematic design direction for mobile app

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,13 +1,15 @@
 import React, { useEffect } from "react"
+import { useColorScheme } from "react-native"
 import { Tabs, Redirect } from "expo-router"
-import { useTheme } from "react-native-paper"
 import { Ionicons } from "@expo/vector-icons"
 import { useAuth } from "../../lib/auth"
 import { registerForPushNotifications } from "../../lib/notifications"
+import { COLORS, SANS_600 } from "../../lib/theme"
 
 export default function TabLayout() {
   const { user } = useAuth()
-  const theme = useTheme()
+  const scheme = useColorScheme()
+  const t = scheme === "dark" ? COLORS.dark : COLORS.light
 
   useEffect(() => {
     if (user) {
@@ -20,41 +22,48 @@ export default function TabLayout() {
   return (
     <Tabs
       screenOptions={{
-        tabBarActiveTintColor: theme.colors.primary,
-        tabBarInactiveTintColor: theme.colors.onSurfaceVariant,
-        tabBarStyle: { backgroundColor: theme.colors.surface },
-        headerStyle: { backgroundColor: theme.colors.surface },
-        headerTintColor: theme.colors.onSurface,
+        tabBarActiveTintColor: t.accent,
+        tabBarInactiveTintColor: t.fgMuted,
+        tabBarStyle: {
+          backgroundColor: t.surface,
+          borderTopColor: t.border,
+          borderTopWidth: 1,
+          elevation: 0,
+          shadowOpacity: 0,
+        },
+        tabBarLabelStyle: {
+          fontFamily: SANS_600,
+          fontSize: 10.5,
+          letterSpacing: 0.1,
+        },
+        headerShown: false,
       }}
     >
       <Tabs.Screen
         name="index"
         options={{
-          title: "Dashboard",
           tabBarLabel: "Home",
           tabBarIcon: ({ color, size }) => (
-            <Ionicons name="home" size={size} color={color} />
+            <Ionicons name="home-outline" size={size} color={color} />
           ),
         }}
       />
       <Tabs.Screen
         name="search"
         options={{
-          title: "Search",
           tabBarLabel: "Search",
           tabBarIcon: ({ color, size }) => (
-            <Ionicons name="search" size={size} color={color} />
+            <Ionicons name="search-outline" size={size} color={color} />
           ),
         }}
       />
       <Tabs.Screen
         name="library"
         options={{
-          title: "Library",
           tabBarLabel: "Library",
           href: "/library",
           tabBarIcon: ({ color, size }) => (
-            <Ionicons name="bookmark" size={size} color={color} />
+            <Ionicons name="bookmark-outline" size={size} color={color} />
           ),
         }}
       />

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -5,7 +5,6 @@ import {
   StyleSheet,
   ImageBackground,
   TouchableOpacity,
-  Dimensions,
 } from "react-native"
 import { Text, ActivityIndicator } from "react-native-paper"
 import { LinearGradient } from "expo-linear-gradient"
@@ -45,7 +44,9 @@ type ShowsResponse = {
 
 function StatusDot({ color }: { color: string }) {
   return (
-    <View style={{ width: 6, height: 6, borderRadius: 3, backgroundColor: color }} />
+    <View
+      style={{ width: 6, height: 6, borderRadius: 3, backgroundColor: color }}
+    />
   )
 }
 
@@ -71,24 +72,55 @@ function HeroSection({
   return (
     <View style={styles.heroContainer}>
       {backdropUri ? (
-        <ImageBackground source={{ uri: backdropUri }} style={styles.heroImage} resizeMode="cover">
+        <ImageBackground
+          source={{ uri: backdropUri }}
+          style={styles.heroImage}
+          resizeMode="cover"
+        >
           <LinearGradient
-            colors={["rgba(0,0,0,0.55)", "transparent", "transparent", "rgba(0,0,0,0.75)", t.bg]}
+            colors={[
+              "rgba(0,0,0,0.55)",
+              "transparent",
+              "transparent",
+              "rgba(0,0,0,0.75)",
+              t.bg,
+            ]}
             locations={[0, 0.25, 0.4, 0.75, 1]}
             style={StyleSheet.absoluteFill}
           />
-          <HeroContent show={show} next={next} sp={sp} onMarkWatched={onMarkWatched} isPending={isPending} insets={insets} t={t} />
+          <HeroContent
+            show={show}
+            next={next}
+            sp={sp}
+            onMarkWatched={onMarkWatched}
+            isPending={isPending}
+            insets={insets}
+          />
         </ImageBackground>
       ) : (
         <View style={[styles.heroImage, { backgroundColor: t.surfaceAlt }]}>
-          <HeroContent show={show} next={next} sp={sp} onMarkWatched={onMarkWatched} isPending={isPending} insets={insets} t={t} />
+          <HeroContent
+            show={show}
+            next={next}
+            sp={sp}
+            onMarkWatched={onMarkWatched}
+            isPending={isPending}
+            insets={insets}
+          />
         </View>
       )}
     </View>
   )
 }
 
-function HeroContent({ show, next, sp, onMarkWatched, isPending, insets, t }: any) {
+function HeroContent({
+  show,
+  next,
+  sp,
+  onMarkWatched,
+  isPending,
+  insets,
+}: any) {
   const router = useRouter()
   return (
     <>
@@ -129,7 +161,7 @@ function HeroContent({ show, next, sp, onMarkWatched, isPending, insets, t }: an
             {isPending ? (
               <ActivityIndicator size="small" color="#000" />
             ) : (
-              <Text style={styles.heroMarkBtnText}>✓  Mark watched</Text>
+              <Text style={styles.heroMarkBtnText}>✓ Mark watched</Text>
             )}
           </TouchableOpacity>
           <TouchableOpacity
@@ -191,7 +223,9 @@ function CarouselSection({
         <Text style={[styles.sectionTitle, { color: t.fg }]}>{title}</Text>
         {total != null && total > DASHBOARD_LIMIT && (
           <TouchableOpacity onPress={() => router.push(href as any)}>
-            <Text style={[styles.seeAll, { color: solidColor }]}>See all →</Text>
+            <Text style={[styles.seeAll, { color: solidColor }]}>
+              See all →
+            </Text>
           </TouchableOpacity>
         )}
       </View>
@@ -204,11 +238,18 @@ function CarouselSection({
           contentContainerStyle={styles.carousel}
         >
           {shows.map((show) => (
-            <CarouselCard key={show.id} show={show} status={status} solidColor={solidColor} />
+            <CarouselCard
+              key={show.id}
+              show={show}
+              status={status}
+              solidColor={solidColor}
+            />
           ))}
         </ScrollView>
       ) : (
-        <Text style={[styles.emptyText, { color: t.fgFaint }]}>Nothing here yet</Text>
+        <Text style={[styles.emptyText, { color: t.fgFaint }]}>
+          Nothing here yet
+        </Text>
       )}
     </View>
   )
@@ -228,7 +269,9 @@ function CarouselCard({
   const posterUri = show.posterPath ? `${TMDB_W300}${show.posterPath}` : null
   const isCaughtUp = status === "caught_up"
   const progress =
-    show.watchedEpisodes != null && show.totalEpisodes != null && show.totalEpisodes > 0
+    show.watchedEpisodes != null &&
+    show.totalEpisodes != null &&
+    show.totalEpisodes > 0
       ? show.watchedEpisodes / show.totalEpisodes
       : null
 
@@ -242,7 +285,9 @@ function CarouselCard({
         {posterUri ? (
           <Image source={{ uri: posterUri }} style={styles.carouselPoster} />
         ) : (
-          <View style={[styles.carouselPoster, { backgroundColor: t.surfaceAlt }]} />
+          <View
+            style={[styles.carouselPoster, { backgroundColor: t.surfaceAlt }]}
+          />
         )}
         {isCaughtUp && show.nextEpisode && (
           <View style={styles.upcomingBadge}>
@@ -257,7 +302,15 @@ function CarouselCard({
         {!isCaughtUp && progress != null && (
           <View style={styles.progressOverlay}>
             <View style={[styles.progressTrack]}>
-              <View style={[styles.progressFill, { width: `${progress * 100}%` as any, backgroundColor: solidColor }]} />
+              <View
+                style={[
+                  styles.progressFill,
+                  {
+                    width: `${progress * 100}%` as any,
+                    backgroundColor: solidColor,
+                  },
+                ]}
+              />
             </View>
           </View>
         )}
@@ -267,10 +320,10 @@ function CarouselCard({
       </Text>
       <Text style={[styles.carouselMeta, { color: t.fgMuted }]}>
         {isCaughtUp
-          ? show.firstAirDate?.slice(0, 4) ?? ""
+          ? (show.firstAirDate?.slice(0, 4) ?? "")
           : show.watchedEpisodes != null && show.totalEpisodes != null
             ? `${show.watchedEpisodes}/${show.totalEpisodes} eps`
-            : show.firstAirDate?.slice(0, 4) ?? ""}
+            : (show.firstAirDate?.slice(0, 4) ?? "")}
       </Text>
     </TouchableOpacity>
   )
@@ -282,9 +335,10 @@ export default function DashboardScreen() {
 
   const { data: stats } = useQuery<Stats>({ queryKey: ["/api/stats"] })
 
-  const { data: watching, isLoading: watchingLoading } = useQuery<ShowsResponse>({
-    queryKey: [`/api/shows/watching?page=1&limit=${DASHBOARD_LIMIT}`],
-  })
+  const { data: watching, isLoading: watchingLoading } =
+    useQuery<ShowsResponse>({
+      queryKey: [`/api/shows/watching?page=1&limit=${DASHBOARD_LIMIT}`],
+    })
   const { data: wantToWatch, isLoading: wtwLoading } = useQuery<ShowsResponse>({
     queryKey: [`/api/shows/want-to-watch?page=1&limit=${DASHBOARD_LIMIT}`],
   })
@@ -305,15 +359,24 @@ export default function DashboardScreen() {
       })
     },
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ["/api/shows", String(featuredShow?.id)] })
-      qc.invalidateQueries({ queryKey: ["/api/shows", String(featuredShow?.id), "progress"] })
-      qc.invalidateQueries({ queryKey: [`/api/shows/watching?page=1&limit=${DASHBOARD_LIMIT}`] })
+      qc.invalidateQueries({
+        queryKey: ["/api/shows", String(featuredShow?.id)],
+      })
+      qc.invalidateQueries({
+        queryKey: ["/api/shows", String(featuredShow?.id), "progress"],
+      })
+      qc.invalidateQueries({
+        queryKey: [`/api/shows/watching?page=1&limit=${DASHBOARD_LIMIT}`],
+      })
       qc.invalidateQueries({ queryKey: ["/api/stats"] })
     },
   })
 
   return (
-    <ScrollView style={{ backgroundColor: t.bg }} contentContainerStyle={{ paddingBottom: 32 }}>
+    <ScrollView
+      style={{ backgroundColor: t.bg }}
+      contentContainerStyle={{ paddingBottom: 32 }}
+    >
       {featuredShow ? (
         <HeroSection
           show={featuredShow}
@@ -321,7 +384,9 @@ export default function DashboardScreen() {
           isPending={markWatched.isPending}
         />
       ) : (
-        <View style={[styles.heroPlaceholder, { backgroundColor: t.surfaceAlt }]} />
+        <View
+          style={[styles.heroPlaceholder, { backgroundColor: t.surfaceAlt }]}
+        />
       )}
 
       {stats && <StatsRow stats={stats} />}

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -1,11 +1,34 @@
 import React from "react"
-import { ScrollView, View, StyleSheet, TouchableOpacity } from "react-native"
-import { Text, Card, useTheme } from "react-native-paper"
-import { useQuery } from "@tanstack/react-query"
+import {
+  ScrollView,
+  View,
+  StyleSheet,
+  ImageBackground,
+  TouchableOpacity,
+  Dimensions,
+} from "react-native"
+import { Text, ActivityIndicator } from "react-native-paper"
+import { LinearGradient } from "expo-linear-gradient"
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { useRouter } from "expo-router"
-import { ShowList } from "../../components/ShowList"
+import { useSafeAreaInsets } from "react-native-safe-area-context"
+import { Image } from "react-native"
+import { apiRequest } from "@showtracker/api-client"
 import type { ShowWithProgress } from "@showtracker/shared"
+import {
+  useAppTheme,
+  STATUS_COLORS,
+  SERIF,
+  SERIF_ITALIC,
+  SANS,
+  SANS_600,
+  SANS_700,
+  MONO,
+  MONO_500,
+} from "../../lib/theme"
 
+const TMDB_W300 = "https://image.tmdb.org/t/p/w300"
+const TMDB_W780 = "https://image.tmdb.org/t/p/w780"
 const DASHBOARD_LIMIT = 6
 
 type Stats = {
@@ -20,174 +43,519 @@ type ShowsResponse = {
   total: number
 }
 
-function StatCard({ label, value }: { label: string; value: number }) {
-  const theme = useTheme()
+function StatusDot({ color }: { color: string }) {
   return (
-    <Card style={styles.statCard}>
-      <Card.Content style={styles.statContent}>
-        <Text variant="headlineMedium" style={{ color: theme.colors.primary }}>
-          {value.toLocaleString()}
-        </Text>
-        <Text
-          variant="bodySmall"
-          style={{ color: theme.colors.onSurfaceVariant }}
-        >
-          {label}
-        </Text>
-      </Card.Content>
-    </Card>
+    <View style={{ width: 6, height: 6, borderRadius: 3, backgroundColor: color }} />
   )
 }
 
-function SectionHeader({
-  title,
-  total,
-  href,
+function HeroSection({
+  show,
+  onMarkWatched,
+  isPending,
 }: {
-  title: string
-  total: number | undefined
-  href: string
+  show: ShowWithProgress
+  onMarkWatched: () => void
+  isPending: boolean
 }) {
-  const theme = useTheme()
-  const router = useRouter()
-  const hasMore = total != null && total > DASHBOARD_LIMIT
+  const t = useAppTheme()
+  const insets = useSafeAreaInsets()
+  const sp = STATUS_COLORS.watching
+  const next = show.nextEpisode
+  const backdropUri = show.backdropPath
+    ? `${TMDB_W780}${show.backdropPath}`
+    : show.posterPath
+      ? `${TMDB_W780}${show.posterPath}`
+      : null
 
   return (
-    <View style={styles.sectionHeader}>
-      <Text variant="titleMedium" style={styles.sectionTitle}>
-        {title}
-      </Text>
-      {hasMore && (
-        <TouchableOpacity
-          onPress={() => router.push(href as any)}
-          style={styles.seeAll}
-        >
-          <Text variant="labelMedium" style={{ color: theme.colors.primary }}>
-            See All ({total})
-          </Text>
-        </TouchableOpacity>
+    <View style={styles.heroContainer}>
+      {backdropUri ? (
+        <ImageBackground source={{ uri: backdropUri }} style={styles.heroImage} resizeMode="cover">
+          <LinearGradient
+            colors={["rgba(0,0,0,0.55)", "transparent", "transparent", "rgba(0,0,0,0.75)", t.bg]}
+            locations={[0, 0.25, 0.4, 0.75, 1]}
+            style={StyleSheet.absoluteFill}
+          />
+          <HeroContent show={show} next={next} sp={sp} onMarkWatched={onMarkWatched} isPending={isPending} insets={insets} t={t} />
+        </ImageBackground>
+      ) : (
+        <View style={[styles.heroImage, { backgroundColor: t.surfaceAlt }]}>
+          <HeroContent show={show} next={next} sp={sp} onMarkWatched={onMarkWatched} isPending={isPending} insets={insets} t={t} />
+        </View>
       )}
     </View>
   )
 }
 
+function HeroContent({ show, next, sp, onMarkWatched, isPending, insets, t }: any) {
+  const router = useRouter()
+  return (
+    <>
+      {/* Top bar */}
+      <View style={[styles.heroTopBar, { paddingTop: insets.top + 12 }]}>
+        <Text style={styles.heroLogo}>Showtracker</Text>
+        <TouchableOpacity style={styles.glassButton} onPress={() => {}}>
+          <Text style={{ color: "#fff", fontSize: 16 }}>⚙</Text>
+        </TouchableOpacity>
+      </View>
+
+      {/* Bottom info */}
+      <View style={styles.heroBottom}>
+        <View style={styles.heroEyebrow}>
+          <StatusDot color={sp.light.solid} />
+          <Text style={styles.heroShowName}>{show.name?.toUpperCase()}</Text>
+        </View>
+        {next ? (
+          <Text style={styles.heroEpisodeTitle} numberOfLines={2}>
+            "{next.title ?? `S${next.season} · E${next.episode}`}"
+          </Text>
+        ) : (
+          <Text style={styles.heroEpisodeTitle}>{show.name}</Text>
+        )}
+        <Text style={styles.heroMeta}>
+          {next ? `S${next.season} · E${next.episode}` : ""}
+          {show.watchedEpisodes != null && show.totalEpisodes != null
+            ? `  ·  ${show.watchedEpisodes}/${show.totalEpisodes} watched`
+            : ""}
+        </Text>
+        <View style={styles.heroActions}>
+          <TouchableOpacity
+            style={styles.heroMarkBtn}
+            onPress={onMarkWatched}
+            disabled={isPending || !next}
+            activeOpacity={0.8}
+          >
+            {isPending ? (
+              <ActivityIndicator size="small" color="#000" />
+            ) : (
+              <Text style={styles.heroMarkBtnText}>✓  Mark watched</Text>
+            )}
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.heroDetailsBtn}
+            onPress={() => router.push(`/shows/${show.id}`)}
+            activeOpacity={0.8}
+          >
+            <Text style={styles.heroDetailsBtnText}>Details</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </>
+  )
+}
+
+function StatsRow({ stats }: { stats: Stats }) {
+  const t = useAppTheme()
+  const items = [
+    { v: stats.totalShows, l: "Shows" },
+    { v: stats.watchingShows, l: "Watching" },
+    { v: stats.completedShows, l: "Done" },
+    { v: stats.episodesWatched.toLocaleString(), l: "Episodes" },
+  ]
+  return (
+    <View style={styles.statsRow}>
+      {items.map((s, i) => (
+        <View key={i} style={styles.statItem}>
+          <Text style={[styles.statValue, { color: t.fg }]}>{s.v}</Text>
+          <Text style={[styles.statLabel, { color: t.fgMuted }]}>{s.l}</Text>
+        </View>
+      ))}
+    </View>
+  )
+}
+
+function CarouselSection({
+  title,
+  shows,
+  status,
+  isLoading,
+  total,
+  href,
+}: {
+  title: string
+  shows: ShowWithProgress[] | undefined
+  status: "watching" | "want_to_watch" | "caught_up"
+  isLoading: boolean
+  total?: number
+  href: string
+}) {
+  const t = useAppTheme()
+  const router = useRouter()
+  const sp = STATUS_COLORS[status]
+  const solidColor = sp.light.solid
+
+  return (
+    <View style={styles.section}>
+      <View style={styles.sectionHeader}>
+        <Text style={[styles.sectionTitle, { color: t.fg }]}>{title}</Text>
+        {total != null && total > DASHBOARD_LIMIT && (
+          <TouchableOpacity onPress={() => router.push(href as any)}>
+            <Text style={[styles.seeAll, { color: solidColor }]}>See all →</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+      {isLoading ? (
+        <ActivityIndicator style={{ marginLeft: 22 }} color={t.fgMuted} />
+      ) : shows && shows.length > 0 ? (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.carousel}
+        >
+          {shows.map((show) => (
+            <CarouselCard key={show.id} show={show} status={status} solidColor={solidColor} />
+          ))}
+        </ScrollView>
+      ) : (
+        <Text style={[styles.emptyText, { color: t.fgFaint }]}>Nothing here yet</Text>
+      )}
+    </View>
+  )
+}
+
+function CarouselCard({
+  show,
+  status,
+  solidColor,
+}: {
+  show: ShowWithProgress
+  status: "watching" | "want_to_watch" | "caught_up"
+  solidColor: string
+}) {
+  const t = useAppTheme()
+  const router = useRouter()
+  const posterUri = show.posterPath ? `${TMDB_W300}${show.posterPath}` : null
+  const isCaughtUp = status === "caught_up"
+  const progress =
+    show.watchedEpisodes != null && show.totalEpisodes != null && show.totalEpisodes > 0
+      ? show.watchedEpisodes / show.totalEpisodes
+      : null
+
+  return (
+    <TouchableOpacity
+      style={styles.carouselCard}
+      onPress={() => router.push(`/shows/${show.id}`)}
+      activeOpacity={0.8}
+    >
+      <View style={styles.carouselPosterWrap}>
+        {posterUri ? (
+          <Image source={{ uri: posterUri }} style={styles.carouselPoster} />
+        ) : (
+          <View style={[styles.carouselPoster, { backgroundColor: t.surfaceAlt }]} />
+        )}
+        {isCaughtUp && show.nextEpisode && (
+          <View style={styles.upcomingBadge}>
+            <Text style={styles.upcomingBadgeText}>
+              S{show.nextEpisode.season}E{show.nextEpisode.episode}{" "}
+              {show.nextEpisode.daysUntil === 0
+                ? "today"
+                : `in ${show.nextEpisode.daysUntil}d`}
+            </Text>
+          </View>
+        )}
+        {!isCaughtUp && progress != null && (
+          <View style={styles.progressOverlay}>
+            <View style={[styles.progressTrack]}>
+              <View style={[styles.progressFill, { width: `${progress * 100}%` as any, backgroundColor: solidColor }]} />
+            </View>
+          </View>
+        )}
+      </View>
+      <Text style={[styles.carouselTitle, { color: t.fg }]} numberOfLines={1}>
+        {show.name}
+      </Text>
+      <Text style={[styles.carouselMeta, { color: t.fgMuted }]}>
+        {isCaughtUp
+          ? show.firstAirDate?.slice(0, 4) ?? ""
+          : show.watchedEpisodes != null && show.totalEpisodes != null
+            ? `${show.watchedEpisodes}/${show.totalEpisodes} eps`
+            : show.firstAirDate?.slice(0, 4) ?? ""}
+      </Text>
+    </TouchableOpacity>
+  )
+}
+
 export default function DashboardScreen() {
-  const theme = useTheme()
+  const t = useAppTheme()
+  const qc = useQueryClient()
 
-  const { data: stats } = useQuery<Stats>({
-    queryKey: ["/api/stats"],
+  const { data: stats } = useQuery<Stats>({ queryKey: ["/api/stats"] })
+
+  const { data: watching, isLoading: watchingLoading } = useQuery<ShowsResponse>({
+    queryKey: [`/api/shows/watching?page=1&limit=${DASHBOARD_LIMIT}`],
   })
-
-  const { data: watching, isLoading: watchingLoading } =
-    useQuery<ShowsResponse>({
-      queryKey: [`/api/shows/watching?page=1&limit=${DASHBOARD_LIMIT}`],
-    })
-
   const { data: wantToWatch, isLoading: wtwLoading } = useQuery<ShowsResponse>({
     queryKey: [`/api/shows/want-to-watch?page=1&limit=${DASHBOARD_LIMIT}`],
   })
-
   const { data: caughtUp, isLoading: cuLoading } = useQuery<ShowsResponse>({
     queryKey: [`/api/shows/caught-up?page=1&limit=${DASHBOARD_LIMIT}`],
   })
 
+  const featuredShow = watching?.shows?.[0]
+
+  const markWatched = useMutation({
+    mutationFn: () => {
+      const next = featuredShow?.nextEpisode
+      if (!next || !featuredShow) throw new Error("No next episode")
+      return apiRequest("POST", `/api/shows/${featuredShow.id}/progress`, {
+        seasonNumber: next.season,
+        episodeNumber: next.episode,
+        watched: true,
+      })
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["/api/shows", String(featuredShow?.id)] })
+      qc.invalidateQueries({ queryKey: ["/api/shows", String(featuredShow?.id), "progress"] })
+      qc.invalidateQueries({ queryKey: [`/api/shows/watching?page=1&limit=${DASHBOARD_LIMIT}`] })
+      qc.invalidateQueries({ queryKey: ["/api/stats"] })
+    },
+  })
+
   return (
-    <ScrollView
-      style={{ backgroundColor: theme.colors.background }}
-      contentContainerStyle={styles.container}
-    >
-      {stats && (
-        <View style={styles.statsGrid}>
-          <View style={styles.statsRow}>
-            <StatCard label="Shows" value={stats.totalShows} />
-            <StatCard label="Watching" value={stats.watchingShows} />
-          </View>
-          <View style={styles.statsRow}>
-            <StatCard label="Completed" value={stats.completedShows} />
-            <StatCard label="Episodes" value={stats.episodesWatched} />
-          </View>
-        </View>
+    <ScrollView style={{ backgroundColor: t.bg }} contentContainerStyle={{ paddingBottom: 32 }}>
+      {featuredShow ? (
+        <HeroSection
+          show={featuredShow}
+          onMarkWatched={() => markWatched.mutate()}
+          isPending={markWatched.isPending}
+        />
+      ) : (
+        <View style={[styles.heroPlaceholder, { backgroundColor: t.surfaceAlt }]} />
       )}
 
-      <View style={styles.section}>
-        <SectionHeader
-          title="Watching"
-          total={watching?.total}
-          href="/(tabs)/library/watching"
-        />
-        <ShowList
-          shows={watching?.shows}
-          isLoading={watchingLoading}
-          horizontal
-          emptyMessage="Nothing watching yet"
-        />
-      </View>
+      {stats && <StatsRow stats={stats} />}
 
-      <View style={styles.section}>
-        <SectionHeader
-          title="Want to Watch"
-          total={wantToWatch?.total}
-          href="/(tabs)/library/want-to-watch"
-        />
-        <ShowList
-          shows={wantToWatch?.shows}
-          isLoading={wtwLoading}
-          horizontal
-          emptyMessage="Nothing queued up"
-        />
-      </View>
-
-      <View style={styles.section}>
-        <SectionHeader
-          title="Caught Up"
-          total={caughtUp?.total}
-          href="/(tabs)/library/caught-up"
-        />
-        <ShowList
-          shows={caughtUp?.shows}
-          isLoading={cuLoading}
-          horizontal
-          emptyMessage="Nothing caught up"
-        />
-      </View>
+      <CarouselSection
+        title="Watching"
+        shows={watching?.shows}
+        status="watching"
+        isLoading={watchingLoading}
+        total={watching?.total}
+        href="/(tabs)/library/watching"
+      />
+      <CarouselSection
+        title="Want to Watch"
+        shows={wantToWatch?.shows}
+        status="want_to_watch"
+        isLoading={wtwLoading}
+        total={wantToWatch?.total}
+        href="/(tabs)/library/want-to-watch"
+      />
+      <CarouselSection
+        title="Caught Up"
+        shows={caughtUp?.shows}
+        status="caught_up"
+        isLoading={cuLoading}
+        total={caughtUp?.total}
+        href="/(tabs)/library/caught-up"
+      />
     </ScrollView>
   )
 }
 
 const styles = StyleSheet.create({
-  container: {
-    padding: 16,
-    gap: 24,
+  heroContainer: {
+    height: 420,
   },
-  statsGrid: {
+  heroImage: {
+    width: "100%",
+    height: 420,
+    justifyContent: "space-between",
+  },
+  heroPlaceholder: {
+    height: 420,
+  },
+  heroTopBar: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingHorizontal: 22,
+  },
+  heroLogo: {
+    fontFamily: SERIF_ITALIC,
+    fontSize: 20,
+    color: "rgba(255,255,255,0.95)",
+  },
+  glassButton: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: "rgba(255,255,255,0.18)",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  heroBottom: {
+    paddingHorizontal: 22,
+    paddingBottom: 22,
+  },
+  heroEyebrow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    marginBottom: 6,
+  },
+  heroShowName: {
+    fontFamily: SANS_700,
+    fontSize: 10.5,
+    color: "rgba(255,255,255,0.85)",
+    letterSpacing: 1.6,
+  },
+  heroEpisodeTitle: {
+    fontFamily: SERIF_ITALIC,
+    fontSize: 28,
+    color: "#fff",
+    letterSpacing: -0.3,
+    lineHeight: 32,
+    marginBottom: 6,
+  },
+  heroMeta: {
+    fontFamily: MONO,
+    fontSize: 12,
+    color: "rgba(255,255,255,0.8)",
+    marginBottom: 14,
+  },
+  heroActions: {
+    flexDirection: "row",
     gap: 8,
+  },
+  heroMarkBtn: {
+    flex: 1,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    borderRadius: 999,
+    backgroundColor: "#fff",
+    alignItems: "center",
+    justifyContent: "center",
+    flexDirection: "row",
+    gap: 6,
+  },
+  heroMarkBtnText: {
+    fontFamily: SANS_700,
+    fontSize: 13.5,
+    color: "#000",
+    letterSpacing: -0.1,
+  },
+  heroDetailsBtn: {
+    paddingVertical: 12,
+    paddingHorizontal: 18,
+    borderRadius: 999,
+    backgroundColor: "rgba(255,255,255,0.18)",
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.25)",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  heroDetailsBtnText: {
+    fontFamily: SANS_600,
+    fontSize: 13.5,
+    color: "#fff",
   },
   statsRow: {
     flexDirection: "row",
-    gap: 8,
+    justifyContent: "space-between",
+    paddingHorizontal: 22,
+    paddingTop: 20,
+    paddingBottom: 4,
   },
-  statCard: {
-    flex: 1,
-  },
-  statContent: {
+  statItem: {
     alignItems: "center",
-    paddingVertical: 12,
+  },
+  statValue: {
+    fontFamily: SERIF,
+    fontSize: 26,
+    letterSpacing: -0.5,
+    lineHeight: 30,
+  },
+  statLabel: {
+    fontFamily: SANS,
+    fontSize: 10,
+    letterSpacing: 0.8,
+    textTransform: "uppercase",
+    marginTop: 4,
   },
   section: {
-    gap: 8,
+    marginTop: 28,
   },
   sectionHeader: {
     flexDirection: "row",
-    alignItems: "center",
+    alignItems: "baseline",
     justifyContent: "space-between",
-    paddingHorizontal: 4,
-  },
-  seeAll: {
-    minHeight: 44,
-    justifyContent: "center",
-    paddingHorizontal: 8,
+    paddingHorizontal: 22,
+    paddingBottom: 12,
   },
   sectionTitle: {
-    fontWeight: "600",
+    fontFamily: SERIF,
+    fontSize: 24,
+    letterSpacing: -0.3,
+  },
+  seeAll: {
+    fontFamily: SANS_600,
+    fontSize: 12,
+  },
+  emptyText: {
+    fontFamily: SANS,
+    fontSize: 13,
+    paddingHorizontal: 22,
+  },
+  carousel: {
+    paddingHorizontal: 22,
+    gap: 14,
+  },
+  carouselCard: {
+    width: 130,
+  },
+  carouselPosterWrap: {
+    position: "relative",
+    borderRadius: 10,
+    overflow: "hidden",
+  },
+  carouselPoster: {
+    width: 130,
+    height: 195,
+    borderRadius: 10,
+  },
+  upcomingBadge: {
+    position: "absolute",
+    top: 8,
+    left: 8,
+    backgroundColor: "rgba(0,0,0,0.7)",
+    borderRadius: 6,
+    paddingHorizontal: 6,
+    paddingVertical: 3,
+  },
+  upcomingBadgeText: {
+    fontFamily: MONO_500,
+    fontSize: 9.5,
+    color: "#fff",
+    letterSpacing: 0.2,
+  },
+  progressOverlay: {
+    position: "absolute",
+    left: 8,
+    right: 8,
+    bottom: 8,
+  },
+  progressTrack: {
+    height: 3,
+    borderRadius: 999,
+    backgroundColor: "rgba(255,255,255,0.25)",
+    overflow: "hidden",
+  },
+  progressFill: {
+    height: "100%",
+    borderRadius: 999,
+  },
+  carouselTitle: {
+    fontFamily: SANS_600,
+    fontSize: 13,
+    letterSpacing: -0.1,
+    lineHeight: 18,
+    marginTop: 8,
+  },
+  carouselMeta: {
+    fontFamily: MONO,
+    fontSize: 11,
+    marginTop: 2,
   },
 })

--- a/apps/mobile/app/(tabs)/library/_layout.tsx
+++ b/apps/mobile/app/(tabs)/library/_layout.tsx
@@ -4,21 +4,61 @@ import { Text } from "react-native-paper"
 import { Slot, useRouter, usePathname } from "expo-router"
 import { useQuery } from "@tanstack/react-query"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
-import { useAppTheme, STATUS_COLORS, SERIF, SANS, SANS_700, MONO } from "../../../lib/theme"
+import {
+  useAppTheme,
+  STATUS_COLORS,
+  SERIF,
+  SANS,
+  SANS_700,
+  MONO,
+} from "../../../lib/theme"
 
 type ShowsResponse = { shows: unknown[]; total: number }
 
 const TABS = [
-  { id: "watching",      label: "Watching",    href: "/(tabs)/library/watching",      segment: "watching",      apiKey: "/api/shows/watching?page=1&limit=1" },
-  { id: "want_to_watch", label: "Want",         href: "/(tabs)/library/want-to-watch", segment: "want-to-watch", apiKey: "/api/shows/want-to-watch?page=1&limit=1" },
-  { id: "caught_up",     label: "Caught Up",    href: "/(tabs)/library/caught-up",     segment: "caught-up",     apiKey: "/api/shows/caught-up?page=1&limit=1" },
-  { id: "completed",     label: "Completed",    href: "/(tabs)/library/completed",     segment: "completed",     apiKey: "/api/shows/completed?page=1&limit=1" },
+  {
+    id: "watching",
+    label: "Watching",
+    href: "/(tabs)/library/watching",
+    segment: "watching",
+    apiKey: "/api/shows/watching?page=1&limit=1",
+  },
+  {
+    id: "want_to_watch",
+    label: "Want",
+    href: "/(tabs)/library/want-to-watch",
+    segment: "want-to-watch",
+    apiKey: "/api/shows/want-to-watch?page=1&limit=1",
+  },
+  {
+    id: "caught_up",
+    label: "Caught Up",
+    href: "/(tabs)/library/caught-up",
+    segment: "caught-up",
+    apiKey: "/api/shows/caught-up?page=1&limit=1",
+  },
+  {
+    id: "completed",
+    label: "Completed",
+    href: "/(tabs)/library/completed",
+    segment: "completed",
+    apiKey: "/api/shows/completed?page=1&limit=1",
+  },
 ] as const
 
 type TabId = (typeof TABS)[number]["id"]
 
 function StatusDot({ color, size = 6 }: { color: string; size?: number }) {
-  return <View style={{ width: size, height: size, borderRadius: size / 2, backgroundColor: color }} />
+  return (
+    <View
+      style={{
+        width: size,
+        height: size,
+        borderRadius: size / 2,
+        backgroundColor: color,
+      }}
+    />
+  )
 }
 
 export default function LibraryLayout() {
@@ -28,23 +68,28 @@ export default function LibraryLayout() {
   const insets = useSafeAreaInsets()
 
   // Fetch total counts for each tab
-  const { data: watchingData } = useQuery<ShowsResponse>({ queryKey: ["/api/shows/watching?page=1&limit=1"] })
-  const { data: wtwData }      = useQuery<ShowsResponse>({ queryKey: ["/api/shows/want-to-watch?page=1&limit=1"] })
-  const { data: cuData }       = useQuery<ShowsResponse>({ queryKey: ["/api/shows/caught-up?page=1&limit=1"] })
-  const { data: compData }     = useQuery<ShowsResponse>({ queryKey: ["/api/shows/completed?page=1&limit=1"] })
+  const { data: watchingData } = useQuery<ShowsResponse>({
+    queryKey: ["/api/shows/watching?page=1&limit=1"],
+  })
+  const { data: wtwData } = useQuery<ShowsResponse>({
+    queryKey: ["/api/shows/want-to-watch?page=1&limit=1"],
+  })
+  const { data: cuData } = useQuery<ShowsResponse>({
+    queryKey: ["/api/shows/caught-up?page=1&limit=1"],
+  })
+  const { data: compData } = useQuery<ShowsResponse>({
+    queryKey: ["/api/shows/completed?page=1&limit=1"],
+  })
 
   const totals: Record<TabId, number | undefined> = {
-    watching:      watchingData?.total,
+    watching: watchingData?.total,
     want_to_watch: wtwData?.total,
-    caught_up:     cuData?.total,
-    completed:     compData?.total,
+    caught_up: cuData?.total,
+    completed: compData?.total,
   }
 
   const activeTab = TABS.find((tab) => pathname.includes(tab.segment))
-  const activeSp = activeTab ? STATUS_COLORS[activeTab.id] : STATUS_COLORS.watching
-
   const activeCount = activeTab ? totals[activeTab.id] : undefined
-  const totalAll = Object.values(totals).reduce<number>((sum, v) => sum + (v ?? 0), 0)
 
   return (
     <View style={[styles.container, { backgroundColor: t.bg }]}>
@@ -60,7 +105,10 @@ export default function LibraryLayout() {
       <ScrollView
         horizontal
         showsHorizontalScrollIndicator={false}
-        contentContainerStyle={[styles.tabsContent, { borderBottomColor: t.border }]}
+        contentContainerStyle={[
+          styles.tabsContent,
+          { borderBottomColor: t.border },
+        ]}
         style={styles.tabsScroll}
       >
         {TABS.map((tab) => {
@@ -82,17 +130,21 @@ export default function LibraryLayout() {
               activeOpacity={0.7}
             >
               <StatusDot color={solidColor} />
-              <Text style={[
-                styles.tabLabel,
-                {
-                  color: isActive ? t.fg : t.fgMuted,
-                  fontFamily: isActive ? SANS_700 : SANS,
-                },
-              ]}>
+              <Text
+                style={[
+                  styles.tabLabel,
+                  {
+                    color: isActive ? t.fg : t.fgMuted,
+                    fontFamily: isActive ? SANS_700 : SANS,
+                  },
+                ]}
+              >
                 {tab.label}
               </Text>
               {count != null && (
-                <Text style={[styles.tabCount, { color: t.fgFaint }]}>{count}</Text>
+                <Text style={[styles.tabCount, { color: t.fgFaint }]}>
+                  {count}
+                </Text>
               )}
             </TouchableOpacity>
           )

--- a/apps/mobile/app/(tabs)/library/_layout.tsx
+++ b/apps/mobile/app/(tabs)/library/_layout.tsx
@@ -1,40 +1,104 @@
-import React, { useState } from "react"
-import { View, StyleSheet } from "react-native"
-import { Chip, useTheme } from "react-native-paper"
+import React from "react"
+import { View, ScrollView, TouchableOpacity, StyleSheet } from "react-native"
+import { Text } from "react-native-paper"
 import { Slot, useRouter, usePathname } from "expo-router"
+import { useQuery } from "@tanstack/react-query"
+import { useSafeAreaInsets } from "react-native-safe-area-context"
+import { useAppTheme, STATUS_COLORS, SERIF, SANS, SANS_700, MONO } from "../../../lib/theme"
+
+type ShowsResponse = { shows: unknown[]; total: number }
 
 const TABS = [
-  { label: "Watching", href: "/(tabs)/library/watching" },
-  { label: "Want", href: "/(tabs)/library/want-to-watch" },
-  { label: "Caught Up", href: "/(tabs)/library/caught-up" },
-  { label: "Completed", href: "/(tabs)/library/completed" },
-]
+  { id: "watching",      label: "Watching",    href: "/(tabs)/library/watching",      segment: "watching",      apiKey: "/api/shows/watching?page=1&limit=1" },
+  { id: "want_to_watch", label: "Want",         href: "/(tabs)/library/want-to-watch", segment: "want-to-watch", apiKey: "/api/shows/want-to-watch?page=1&limit=1" },
+  { id: "caught_up",     label: "Caught Up",    href: "/(tabs)/library/caught-up",     segment: "caught-up",     apiKey: "/api/shows/caught-up?page=1&limit=1" },
+  { id: "completed",     label: "Completed",    href: "/(tabs)/library/completed",     segment: "completed",     apiKey: "/api/shows/completed?page=1&limit=1" },
+] as const
+
+type TabId = (typeof TABS)[number]["id"]
+
+function StatusDot({ color, size = 6 }: { color: string; size?: number }) {
+  return <View style={{ width: size, height: size, borderRadius: size / 2, backgroundColor: color }} />
+}
 
 export default function LibraryLayout() {
-  const theme = useTheme()
+  const t = useAppTheme()
   const router = useRouter()
   const pathname = usePathname()
+  const insets = useSafeAreaInsets()
+
+  // Fetch total counts for each tab
+  const { data: watchingData } = useQuery<ShowsResponse>({ queryKey: ["/api/shows/watching?page=1&limit=1"] })
+  const { data: wtwData }      = useQuery<ShowsResponse>({ queryKey: ["/api/shows/want-to-watch?page=1&limit=1"] })
+  const { data: cuData }       = useQuery<ShowsResponse>({ queryKey: ["/api/shows/caught-up?page=1&limit=1"] })
+  const { data: compData }     = useQuery<ShowsResponse>({ queryKey: ["/api/shows/completed?page=1&limit=1"] })
+
+  const totals: Record<TabId, number | undefined> = {
+    watching:      watchingData?.total,
+    want_to_watch: wtwData?.total,
+    caught_up:     cuData?.total,
+    completed:     compData?.total,
+  }
+
+  const activeTab = TABS.find((tab) => pathname.includes(tab.segment))
+  const activeSp = activeTab ? STATUS_COLORS[activeTab.id] : STATUS_COLORS.watching
+
+  const activeCount = activeTab ? totals[activeTab.id] : undefined
+  const totalAll = Object.values(totals).reduce<number>((sum, v) => sum + (v ?? 0), 0)
 
   return (
-    <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
-      <View
-        style={[styles.tabBar, { backgroundColor: theme.colors.surface }]}
+    <View style={[styles.container, { backgroundColor: t.bg }]}>
+      {/* Header */}
+      <View style={[styles.header, { paddingTop: insets.top + 14 }]}>
+        <Text style={[styles.eyebrow, { color: t.fgFaint }]}>
+          {activeCount != null ? `${activeCount} SHOWS` : ""}
+        </Text>
+        <Text style={[styles.title, { color: t.fg }]}>Library</Text>
+      </View>
+
+      {/* Underline tabs */}
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={[styles.tabsContent, { borderBottomColor: t.border }]}
+        style={styles.tabsScroll}
       >
         {TABS.map((tab) => {
-          const isActive = pathname.includes(tab.href.split("/").pop() ?? "")
+          const isActive = pathname.includes(tab.segment)
+          const sp = STATUS_COLORS[tab.id]
+          const solidColor = sp.light.solid
+          const count = totals[tab.id]
           return (
-            <Chip
-              key={tab.href}
-              selected={isActive}
+            <TouchableOpacity
+              key={tab.id}
               onPress={() => router.push(tab.href as any)}
-              style={styles.chip}
-              compact
+              style={[
+                styles.tab,
+                {
+                  borderBottomColor: isActive ? solidColor : "transparent",
+                  borderBottomWidth: 2,
+                },
+              ]}
+              activeOpacity={0.7}
             >
-              {tab.label}
-            </Chip>
+              <StatusDot color={solidColor} />
+              <Text style={[
+                styles.tabLabel,
+                {
+                  color: isActive ? t.fg : t.fgMuted,
+                  fontFamily: isActive ? SANS_700 : SANS,
+                },
+              ]}>
+                {tab.label}
+              </Text>
+              {count != null && (
+                <Text style={[styles.tabCount, { color: t.fgFaint }]}>{count}</Text>
+              )}
+            </TouchableOpacity>
           )
         })}
-      </View>
+      </ScrollView>
+
       <View style={styles.content}>
         <Slot />
       </View>
@@ -43,14 +107,49 @@ export default function LibraryLayout() {
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1 },
-  tabBar: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    padding: 8,
-    gap: 6,
-    elevation: 2,
+  container: {
+    flex: 1,
   },
-  chip: { flexShrink: 1 },
-  content: { flex: 1 },
+  header: {
+    paddingHorizontal: 22,
+    paddingBottom: 16,
+  },
+  eyebrow: {
+    fontFamily: SANS,
+    fontSize: 11,
+    letterSpacing: 1.2,
+    marginBottom: 4,
+  },
+  title: {
+    fontFamily: SERIF,
+    fontSize: 44,
+    letterSpacing: -0.8,
+    lineHeight: 44,
+  },
+  tabsScroll: {
+    flexGrow: 0,
+  },
+  tabsContent: {
+    paddingHorizontal: 22,
+    gap: 18,
+    borderBottomWidth: 1,
+    paddingBottom: 0,
+  },
+  tab: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    paddingBottom: 12,
+    marginBottom: -1,
+  },
+  tabLabel: {
+    fontSize: 13.5,
+  },
+  tabCount: {
+    fontFamily: MONO,
+    fontSize: 11,
+  },
+  content: {
+    flex: 1,
+  },
 })

--- a/apps/mobile/app/(tabs)/library/caught-up.tsx
+++ b/apps/mobile/app/(tabs)/library/caught-up.tsx
@@ -6,8 +6,13 @@ import type { ShowWithProgress } from "@showtracker/shared"
 const PAGE_SIZE = 40
 
 export default function CaughtUpScreen() {
-  const { data, isLoading } = useQuery<{ shows: ShowWithProgress[]; total: number }>({
+  const { data, isLoading } = useQuery<{
+    shows: ShowWithProgress[]
+    total: number
+  }>({
     queryKey: [`/api/shows/caught-up?page=1&limit=${PAGE_SIZE}`],
   })
-  return <PosterGrid shows={data?.shows} isLoading={isLoading} status="caught_up" />
+  return (
+    <PosterGrid shows={data?.shows} isLoading={isLoading} status="caught_up" />
+  )
 }

--- a/apps/mobile/app/(tabs)/library/caught-up.tsx
+++ b/apps/mobile/app/(tabs)/library/caught-up.tsx
@@ -1,17 +1,13 @@
 import React from "react"
 import { useQuery } from "@tanstack/react-query"
-import { ShowList } from "../../../components/ShowList"
+import { PosterGrid } from "../../../components/PosterGrid"
 import type { ShowWithProgress } from "@showtracker/shared"
 
+const PAGE_SIZE = 40
+
 export default function CaughtUpScreen() {
-  const { data, isLoading } = useQuery<{ shows: ShowWithProgress[] }>({
-    queryKey: ["/api/shows/caught-up?page=1&limit=50"],
+  const { data, isLoading } = useQuery<{ shows: ShowWithProgress[]; total: number }>({
+    queryKey: [`/api/shows/caught-up?page=1&limit=${PAGE_SIZE}`],
   })
-  return (
-    <ShowList
-      shows={data?.shows}
-      isLoading={isLoading}
-      emptyMessage="No shows caught up yet."
-    />
-  )
+  return <PosterGrid shows={data?.shows} isLoading={isLoading} status="caught_up" />
 }

--- a/apps/mobile/app/(tabs)/library/completed.tsx
+++ b/apps/mobile/app/(tabs)/library/completed.tsx
@@ -1,17 +1,13 @@
 import React from "react"
 import { useQuery } from "@tanstack/react-query"
-import { ShowList } from "../../../components/ShowList"
+import { PosterGrid } from "../../../components/PosterGrid"
 import type { ShowWithProgress } from "@showtracker/shared"
 
+const PAGE_SIZE = 40
+
 export default function CompletedScreen() {
-  const { data, isLoading } = useQuery<{ shows: ShowWithProgress[] }>({
-    queryKey: ["/api/shows/completed?page=1&limit=50"],
+  const { data, isLoading } = useQuery<{ shows: ShowWithProgress[]; total: number }>({
+    queryKey: [`/api/shows/completed?page=1&limit=${PAGE_SIZE}`],
   })
-  return (
-    <ShowList
-      shows={data?.shows}
-      isLoading={isLoading}
-      emptyMessage="No completed shows yet."
-    />
-  )
+  return <PosterGrid shows={data?.shows} isLoading={isLoading} status="completed" />
 }

--- a/apps/mobile/app/(tabs)/library/completed.tsx
+++ b/apps/mobile/app/(tabs)/library/completed.tsx
@@ -6,8 +6,13 @@ import type { ShowWithProgress } from "@showtracker/shared"
 const PAGE_SIZE = 40
 
 export default function CompletedScreen() {
-  const { data, isLoading } = useQuery<{ shows: ShowWithProgress[]; total: number }>({
+  const { data, isLoading } = useQuery<{
+    shows: ShowWithProgress[]
+    total: number
+  }>({
     queryKey: [`/api/shows/completed?page=1&limit=${PAGE_SIZE}`],
   })
-  return <PosterGrid shows={data?.shows} isLoading={isLoading} status="completed" />
+  return (
+    <PosterGrid shows={data?.shows} isLoading={isLoading} status="completed" />
+  )
 }

--- a/apps/mobile/app/(tabs)/library/want-to-watch.tsx
+++ b/apps/mobile/app/(tabs)/library/want-to-watch.tsx
@@ -6,8 +6,17 @@ import type { ShowWithProgress } from "@showtracker/shared"
 const PAGE_SIZE = 40
 
 export default function WantToWatchScreen() {
-  const { data, isLoading } = useQuery<{ shows: ShowWithProgress[]; total: number }>({
+  const { data, isLoading } = useQuery<{
+    shows: ShowWithProgress[]
+    total: number
+  }>({
     queryKey: [`/api/shows/want-to-watch?page=1&limit=${PAGE_SIZE}`],
   })
-  return <PosterGrid shows={data?.shows} isLoading={isLoading} status="want_to_watch" />
+  return (
+    <PosterGrid
+      shows={data?.shows}
+      isLoading={isLoading}
+      status="want_to_watch"
+    />
+  )
 }

--- a/apps/mobile/app/(tabs)/library/want-to-watch.tsx
+++ b/apps/mobile/app/(tabs)/library/want-to-watch.tsx
@@ -1,17 +1,13 @@
 import React from "react"
 import { useQuery } from "@tanstack/react-query"
-import { ShowList } from "../../../components/ShowList"
+import { PosterGrid } from "../../../components/PosterGrid"
 import type { ShowWithProgress } from "@showtracker/shared"
 
+const PAGE_SIZE = 40
+
 export default function WantToWatchScreen() {
-  const { data, isLoading } = useQuery<{ shows: ShowWithProgress[] }>({
-    queryKey: ["/api/shows/want-to-watch?page=1&limit=50"],
+  const { data, isLoading } = useQuery<{ shows: ShowWithProgress[]; total: number }>({
+    queryKey: [`/api/shows/want-to-watch?page=1&limit=${PAGE_SIZE}`],
   })
-  return (
-    <ShowList
-      shows={data?.shows}
-      isLoading={isLoading}
-      emptyMessage="Nothing queued up yet."
-    />
-  )
+  return <PosterGrid shows={data?.shows} isLoading={isLoading} status="want_to_watch" />
 }

--- a/apps/mobile/app/(tabs)/library/watching.tsx
+++ b/apps/mobile/app/(tabs)/library/watching.tsx
@@ -1,20 +1,13 @@
-import React, { useState } from "react"
+import React from "react"
 import { useQuery } from "@tanstack/react-query"
-import { ShowList } from "../../../components/ShowList"
+import { PosterGrid } from "../../../components/PosterGrid"
 import type { ShowWithProgress } from "@showtracker/shared"
 
-const PAGE_SIZE = 20
+const PAGE_SIZE = 40
 
 export default function WatchingScreen() {
-  const [page] = useState(1)
-  const { data, isLoading } = useQuery<{ shows: ShowWithProgress[] }>({
-    queryKey: [`/api/shows/watching?page=${page}&limit=${PAGE_SIZE}`],
+  const { data, isLoading } = useQuery<{ shows: ShowWithProgress[]; total: number }>({
+    queryKey: [`/api/shows/watching?page=1&limit=${PAGE_SIZE}`],
   })
-  return (
-    <ShowList
-      shows={data?.shows}
-      isLoading={isLoading}
-      emptyMessage="No shows in progress."
-    />
-  )
+  return <PosterGrid shows={data?.shows} isLoading={isLoading} status="watching" />
 }

--- a/apps/mobile/app/(tabs)/library/watching.tsx
+++ b/apps/mobile/app/(tabs)/library/watching.tsx
@@ -6,8 +6,13 @@ import type { ShowWithProgress } from "@showtracker/shared"
 const PAGE_SIZE = 40
 
 export default function WatchingScreen() {
-  const { data, isLoading } = useQuery<{ shows: ShowWithProgress[]; total: number }>({
+  const { data, isLoading } = useQuery<{
+    shows: ShowWithProgress[]
+    total: number
+  }>({
     queryKey: [`/api/shows/watching?page=1&limit=${PAGE_SIZE}`],
   })
-  return <PosterGrid shows={data?.shows} isLoading={isLoading} status="watching" />
+  return (
+    <PosterGrid shows={data?.shows} isLoading={isLoading} status="watching" />
+  )
 }

--- a/apps/mobile/app/(tabs)/search.tsx
+++ b/apps/mobile/app/(tabs)/search.tsx
@@ -9,7 +9,12 @@ import {
   ActivityIndicator as RNActivityIndicator,
 } from "react-native"
 import { Text, Menu, ActivityIndicator } from "react-native-paper"
-import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
 import { useRouter } from "expo-router"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { apiRequest } from "@showtracker/api-client"
@@ -45,7 +50,7 @@ function useDebounce<T>(value: T, delay: number): T {
   return debounced
 }
 
-function CollectionBadge({ status, t }: { status: StatusKey; t: ReturnType<typeof useAppTheme> }) {
+function CollectionBadge({ status }: { status: StatusKey }) {
   const sp = STATUS_COLORS[status]
   return (
     <View style={[styles.collectionBadge, { backgroundColor: sp.light.solid }]}>
@@ -96,7 +101,7 @@ function SearchResultRow({
         ) : (
           <View style={[styles.poster, { backgroundColor: t.surfaceAlt }]} />
         )}
-        {collectionStatus && <CollectionBadge status={collectionStatus} t={t} />}
+        {collectionStatus && <CollectionBadge status={collectionStatus} />}
       </View>
 
       {/* Info */}
@@ -121,14 +126,25 @@ function SearchResultRow({
           {collectionStatus && (
             <>
               <View style={[styles.metaDot, { backgroundColor: t.fgFaint }]} />
-              <Text style={[styles.metaText, { color: STATUS_COLORS[collectionStatus].light.fg, fontFamily: MONO_500 }]}>
+              <Text
+                style={[
+                  styles.metaText,
+                  {
+                    color: STATUS_COLORS[collectionStatus].light.fg,
+                    fontFamily: MONO_500,
+                  },
+                ]}
+              >
                 In {STATUS_LABELS[collectionStatus]}
               </Text>
             </>
           )}
         </View>
         {show.overview ? (
-          <Text style={[styles.overview, { color: t.fgMuted }]} numberOfLines={2}>
+          <Text
+            style={[styles.overview, { color: t.fgMuted }]}
+            numberOfLines={2}
+          >
             {show.overview}
           </Text>
         ) : null}
@@ -148,28 +164,42 @@ function SearchResultRow({
                 {isPending ? (
                   <RNActivityIndicator size="small" color={t.fg} />
                 ) : (
-                  <Text style={[styles.addBtnText, { color: t.fg }]}>+ Add</Text>
+                  <Text style={[styles.addBtnText, { color: t.fg }]}>
+                    + Add
+                  </Text>
                 )}
               </TouchableOpacity>
             }
           >
             <Menu.Item
-              onPress={() => { onAdd(show.id, "want_to_watch"); setMenuVisible(false) }}
+              onPress={() => {
+                onAdd(show.id, "want_to_watch")
+                setMenuVisible(false)
+              }}
               title="Want to Watch"
             />
             <Menu.Item
-              onPress={() => { onAdd(show.id, "watching"); setMenuVisible(false) }}
+              onPress={() => {
+                onAdd(show.id, "watching")
+                setMenuVisible(false)
+              }}
               title="Watching"
             />
             {isEnded && (
               <Menu.Item
-                onPress={() => { onAdd(show.id, "completed"); setMenuVisible(false) }}
+                onPress={() => {
+                  onAdd(show.id, "completed")
+                  setMenuVisible(false)
+                }}
                 title="Mark as Completed"
               />
             )}
             {isReturning && (
               <Menu.Item
-                onPress={() => { onAdd(show.id, "caught_up"); setMenuVisible(false) }}
+                onPress={() => {
+                  onAdd(show.id, "caught_up")
+                  setMenuVisible(false)
+                }}
                 title="Mark as Caught Up"
               />
             )}
@@ -204,13 +234,27 @@ export default function SearchScreen() {
       enabled: debouncedQuery.length >= 2,
     })
 
-  const results = useMemo(() => data?.pages.flatMap((p) => p.results) ?? [], [data])
+  const results = useMemo(
+    () => data?.pages.flatMap((p) => p.results) ?? [],
+    [data]
+  )
 
-  const { data: userShows } = useQuery<UserShow[]>({ queryKey: ["/api/user/shows"] })
+  const { data: userShows } = useQuery<UserShow[]>({
+    queryKey: ["/api/user/shows"],
+  })
 
   const addMutation = useMutation({
-    mutationFn: async ({ showId, status }: { showId: number; status?: string }) => {
-      await apiRequest("POST", "/api/user/shows", { showId, status: status ?? "want_to_watch" })
+    mutationFn: async ({
+      showId,
+      status,
+    }: {
+      showId: number
+      status?: string
+    }) => {
+      await apiRequest("POST", "/api/user/shows", {
+        showId,
+        status: status ?? "want_to_watch",
+      })
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["/api/user/shows"] })
@@ -218,7 +262,8 @@ export default function SearchScreen() {
     },
   })
 
-  const findUserShow = (showId: number) => userShows?.find((us) => us.showId === showId)
+  const findUserShow = (showId: number) =>
+    userShows?.find((us) => us.showId === showId)
 
   return (
     <View style={[styles.container, { backgroundColor: t.bg }]}>
@@ -229,7 +274,12 @@ export default function SearchScreen() {
 
       {/* Search input */}
       <View style={styles.inputWrap}>
-        <View style={[styles.inputContainer, { backgroundColor: t.surface, borderColor: t.border }]}>
+        <View
+          style={[
+            styles.inputContainer,
+            { backgroundColor: t.surface, borderColor: t.border },
+          ]}
+        >
           <Text style={[styles.searchIcon, { color: t.fgMuted }]}>⌕</Text>
           <TextInput
             ref={inputRef}
@@ -242,7 +292,10 @@ export default function SearchScreen() {
             autoCorrect={false}
           />
           {query.length > 0 && (
-            <TouchableOpacity onPress={() => setQuery("")} style={styles.clearBtn}>
+            <TouchableOpacity
+              onPress={() => setQuery("")}
+              style={styles.clearBtn}
+            >
               <Text style={[styles.clearBtnText, { color: t.fgMuted }]}>✕</Text>
             </TouchableOpacity>
           )}
@@ -255,7 +308,9 @@ export default function SearchScreen() {
       {/* Empty / no-query state */}
       {!debouncedQuery && (
         <View style={styles.emptyState}>
-          <Text style={[styles.emptyTitle, { color: t.fg }]}>Start Searching</Text>
+          <Text style={[styles.emptyTitle, { color: t.fg }]}>
+            Start Searching
+          </Text>
           <Text style={[styles.emptyBody, { color: t.fgMuted }]}>
             Enter a TV show name to search and add to your collection.
           </Text>
@@ -284,10 +339,14 @@ export default function SearchScreen() {
         )}
         contentContainerStyle={styles.list}
         keyboardDismissMode="on-drag"
-        onEndReached={() => { if (hasNextPage && !isFetchingNextPage) fetchNextPage() }}
+        onEndReached={() => {
+          if (hasNextPage && !isFetchingNextPage) fetchNextPage()
+        }}
         onEndReachedThreshold={0.4}
         ListFooterComponent={
-          isFetchingNextPage ? <ActivityIndicator style={styles.loadingMore} /> : null
+          isFetchingNextPage ? (
+            <ActivityIndicator style={styles.loadingMore} />
+          ) : null
         }
       />
     </View>

--- a/apps/mobile/app/(tabs)/search.tsx
+++ b/apps/mobile/app/(tabs)/search.tsx
@@ -1,26 +1,33 @@
-import React, { useState, useMemo } from "react"
-import { View, FlatList, StyleSheet, Image } from "react-native"
+import React, { useState, useMemo, useRef } from "react"
 import {
-  Searchbar,
-  Card,
-  Text,
-  Button,
-  Chip,
-  Menu,
-  ActivityIndicator,
-  useTheme,
-} from "react-native-paper"
-import {
-  useInfiniteQuery,
-  useMutation,
-  useQuery,
-  useQueryClient,
-} from "@tanstack/react-query"
+  View,
+  FlatList,
+  StyleSheet,
+  Image,
+  TextInput,
+  TouchableOpacity,
+  ActivityIndicator as RNActivityIndicator,
+} from "react-native"
+import { Text, Menu, ActivityIndicator } from "react-native-paper"
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useRouter } from "expo-router"
+import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { apiRequest } from "@showtracker/api-client"
 import type { TMDBShow, UserShow } from "@showtracker/shared"
+import {
+  useAppTheme,
+  STATUS_COLORS,
+  StatusKey,
+  STATUS_LABELS,
+  SERIF,
+  SANS,
+  SANS_600,
+  SANS_700,
+  MONO,
+  MONO_500,
+} from "../../lib/theme"
 
-const TMDB_IMAGE_BASE = "https://image.tmdb.org/t/p/w200"
+const TMDB_W200 = "https://image.tmdb.org/t/p/w200"
 
 interface SearchResponse {
   results: TMDBShow[]
@@ -38,7 +45,16 @@ function useDebounce<T>(value: T, delay: number): T {
   return debounced
 }
 
-function AddButton({
+function CollectionBadge({ status, t }: { status: StatusKey; t: ReturnType<typeof useAppTheme> }) {
+  const sp = STATUS_COLORS[status]
+  return (
+    <View style={[styles.collectionBadge, { backgroundColor: sp.light.solid }]}>
+      <Text style={styles.collectionBadgeText}>✓</Text>
+    </View>
+  )
+}
+
+function SearchResultRow({
   show,
   userShow,
   onAdd,
@@ -49,135 +65,152 @@ function AddButton({
   onAdd: (showId: number, status?: string) => void
   isPending: boolean
 }) {
+  const t = useAppTheme()
+  const router = useRouter()
   const [menuVisible, setMenuVisible] = useState(false)
 
-  const { data: showDetail, isLoading: detailLoading } = useQuery<{
-    status?: string
-  }>({
+  const { data: showDetail } = useQuery<{ status?: string }>({
     queryKey: ["/api/shows", show.id],
     enabled: menuVisible && show.status == null,
   })
 
   const effectiveStatus = show.status ?? showDetail?.status
-  const isEnded =
-    effectiveStatus === "Ended" || effectiveStatus === "Canceled"
+  const isEnded = effectiveStatus === "Ended" || effectiveStatus === "Canceled"
   const isReturning = effectiveStatus === "Returning Series"
 
-  if (userShow) {
-    return (
-      <Chip icon="check" style={styles.inCollectionChip} compact>
-        In Collection
-      </Chip>
-    )
-  }
+  const collectionStatus = userShow?.status as StatusKey | undefined
 
   return (
-    <View style={styles.addRow}>
-      <Button
-        mode="outlined"
-        compact
-        onPress={() => onAdd(show.id)}
-        loading={isPending}
-        disabled={isPending}
-        style={styles.addButton}
-      >
-        Add
-      </Button>
-      <Menu
-        visible={menuVisible}
-        onDismiss={() => setMenuVisible(false)}
-        anchor={
-          <Button
-            mode="outlined"
-            compact
-            onPress={() => setMenuVisible(true)}
-            disabled={isPending}
-            style={styles.chevronButton}
+    <TouchableOpacity
+      style={[styles.resultRow, { borderBottomColor: t.border }]}
+      onPress={() => router.push(`/shows/${show.id}`)}
+      activeOpacity={0.7}
+    >
+      {/* Poster */}
+      <View style={styles.posterWrap}>
+        {show.poster_path ? (
+          <Image
+            source={{ uri: `${TMDB_W200}${show.poster_path}` }}
+            style={styles.poster}
+          />
+        ) : (
+          <View style={[styles.poster, { backgroundColor: t.surfaceAlt }]} />
+        )}
+        {collectionStatus && <CollectionBadge status={collectionStatus} t={t} />}
+      </View>
+
+      {/* Info */}
+      <View style={styles.info}>
+        <Text style={[styles.showTitle, { color: t.fg }]} numberOfLines={2}>
+          {show.name}
+        </Text>
+        <View style={styles.metaRow}>
+          {show.first_air_date && (
+            <Text style={[styles.metaText, { color: t.fgMuted }]}>
+              {show.first_air_date.slice(0, 4)}
+            </Text>
+          )}
+          {show.vote_average > 0 && (
+            <>
+              <View style={[styles.metaDot, { backgroundColor: t.fgFaint }]} />
+              <Text style={[styles.metaText, { color: t.fgMuted }]}>
+                ★ {show.vote_average.toFixed(1)}
+              </Text>
+            </>
+          )}
+          {collectionStatus && (
+            <>
+              <View style={[styles.metaDot, { backgroundColor: t.fgFaint }]} />
+              <Text style={[styles.metaText, { color: STATUS_COLORS[collectionStatus].light.fg, fontFamily: MONO_500 }]}>
+                In {STATUS_LABELS[collectionStatus]}
+              </Text>
+            </>
+          )}
+        </View>
+        {show.overview ? (
+          <Text style={[styles.overview, { color: t.fgMuted }]} numberOfLines={2}>
+            {show.overview}
+          </Text>
+        ) : null}
+        {!userShow && (
+          <Menu
+            visible={menuVisible}
+            onDismiss={() => setMenuVisible(false)}
+            anchor={
+              <TouchableOpacity
+                style={[styles.addBtn, { borderColor: t.fg }]}
+                onPress={() => {
+                  if (isPending) return
+                  setMenuVisible(true)
+                }}
+                activeOpacity={0.7}
+              >
+                {isPending ? (
+                  <RNActivityIndicator size="small" color={t.fg} />
+                ) : (
+                  <Text style={[styles.addBtnText, { color: t.fg }]}>+ Add</Text>
+                )}
+              </TouchableOpacity>
+            }
           >
-            ▾
-          </Button>
-        }
-      >
-        <Menu.Item
-          onPress={() => {
-            onAdd(show.id, "want_to_watch")
-            setMenuVisible(false)
-          }}
-          title="Want to Watch"
-        />
-        {detailLoading && <Menu.Item title="Loading…" disabled />}
-        {isEnded && (
-          <Menu.Item
-            onPress={() => {
-              onAdd(show.id, "completed")
-              setMenuVisible(false)
-            }}
-            title="Mark as Completed"
-          />
+            <Menu.Item
+              onPress={() => { onAdd(show.id, "want_to_watch"); setMenuVisible(false) }}
+              title="Want to Watch"
+            />
+            <Menu.Item
+              onPress={() => { onAdd(show.id, "watching"); setMenuVisible(false) }}
+              title="Watching"
+            />
+            {isEnded && (
+              <Menu.Item
+                onPress={() => { onAdd(show.id, "completed"); setMenuVisible(false) }}
+                title="Mark as Completed"
+              />
+            )}
+            {isReturning && (
+              <Menu.Item
+                onPress={() => { onAdd(show.id, "caught_up"); setMenuVisible(false) }}
+                title="Mark as Caught Up"
+              />
+            )}
+          </Menu>
         )}
-        {isReturning && (
-          <Menu.Item
-            onPress={() => {
-              onAdd(show.id, "caught_up")
-              setMenuVisible(false)
-            }}
-            title="Mark as Caught Up"
-          />
-        )}
-      </Menu>
-    </View>
+      </View>
+    </TouchableOpacity>
   )
 }
 
 export default function SearchScreen() {
   const [query, setQuery] = useState("")
   const debouncedQuery = useDebounce(query, 400)
-  const router = useRouter()
-  const theme = useTheme()
+  const t = useAppTheme()
   const qc = useQueryClient()
+  const insets = useSafeAreaInsets()
+  const inputRef = useRef<TextInput>(null)
 
-  const {
-    data,
-    isLoading,
-    isFetchingNextPage,
-    hasNextPage,
-    fetchNextPage,
-  } = useInfiniteQuery<SearchResponse>({
-    queryKey: ["/api/search/shows", debouncedQuery],
-    queryFn: async ({ pageParam = 1 }) => {
-      const res = await apiRequest(
-        "GET",
-        `/api/search/shows/${encodeURIComponent(debouncedQuery)}?page=${pageParam}`
-      )
-      return res.json()
-    },
-    getNextPageParam: (lastPage) =>
-      lastPage.page < lastPage.totalPages ? lastPage.page + 1 : undefined,
-    initialPageParam: 1,
-    enabled: debouncedQuery.length >= 2,
-  })
+  const { data, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } =
+    useInfiniteQuery<SearchResponse>({
+      queryKey: ["/api/search/shows", debouncedQuery],
+      queryFn: async ({ pageParam = 1 }) => {
+        const res = await apiRequest(
+          "GET",
+          `/api/search/shows/${encodeURIComponent(debouncedQuery)}?page=${pageParam}`
+        )
+        return res.json()
+      },
+      getNextPageParam: (lastPage) =>
+        lastPage.page < lastPage.totalPages ? lastPage.page + 1 : undefined,
+      initialPageParam: 1,
+      enabled: debouncedQuery.length >= 2,
+    })
 
-  const results = useMemo(
-    () => data?.pages.flatMap((p) => p.results) ?? [],
-    [data]
-  )
+  const results = useMemo(() => data?.pages.flatMap((p) => p.results) ?? [], [data])
 
-  const { data: userShows } = useQuery<UserShow[]>({
-    queryKey: ["/api/user/shows"],
-  })
+  const { data: userShows } = useQuery<UserShow[]>({ queryKey: ["/api/user/shows"] })
 
   const addMutation = useMutation({
-    mutationFn: async ({
-      showId,
-      status,
-    }: {
-      showId: number
-      status?: string
-    }) => {
-      await apiRequest("POST", "/api/user/shows", {
-        showId,
-        status: status ?? "want_to_watch",
-      })
+    mutationFn: async ({ showId, status }: { showId: number; status?: string }) => {
+      await apiRequest("POST", "/api/user/shows", { showId, status: status ?? "want_to_watch" })
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["/api/user/shows"] })
@@ -185,120 +218,76 @@ export default function SearchScreen() {
     },
   })
 
-  const findUserShow = (showId: number) =>
-    userShows?.find((us) => us.showId === showId)
+  const findUserShow = (showId: number) => userShows?.find((us) => us.showId === showId)
 
   return (
-    <View
-      style={[styles.container, { backgroundColor: theme.colors.background }]}
-    >
-      <Searchbar
-        placeholder="Search TV shows..."
-        value={query}
-        onChangeText={setQuery}
-        style={styles.searchbar}
-        loading={isLoading && debouncedQuery.length >= 2}
-      />
+    <View style={[styles.container, { backgroundColor: t.bg }]}>
+      {/* Header */}
+      <View style={[styles.header, { paddingTop: insets.top + 14 }]}>
+        <Text style={[styles.title, { color: t.fg }]}>Search</Text>
+      </View>
 
+      {/* Search input */}
+      <View style={styles.inputWrap}>
+        <View style={[styles.inputContainer, { backgroundColor: t.surface, borderColor: t.border }]}>
+          <Text style={[styles.searchIcon, { color: t.fgMuted }]}>⌕</Text>
+          <TextInput
+            ref={inputRef}
+            style={[styles.input, { color: t.fg, fontFamily: SANS }]}
+            placeholder="Search TV shows…"
+            placeholderTextColor={t.fgFaint}
+            value={query}
+            onChangeText={setQuery}
+            returnKeyType="search"
+            autoCorrect={false}
+          />
+          {query.length > 0 && (
+            <TouchableOpacity onPress={() => setQuery("")} style={styles.clearBtn}>
+              <Text style={[styles.clearBtnText, { color: t.fgMuted }]}>✕</Text>
+            </TouchableOpacity>
+          )}
+          {isLoading && debouncedQuery.length >= 2 && (
+            <ActivityIndicator size="small" color={t.fgMuted} />
+          )}
+        </View>
+      </View>
+
+      {/* Empty / no-query state */}
       {!debouncedQuery && (
         <View style={styles.emptyState}>
-          <Text variant="titleMedium">Start Searching</Text>
-          <Text
-            variant="bodyMedium"
-            style={{ color: theme.colors.onSurfaceVariant, marginTop: 4 }}
-          >
+          <Text style={[styles.emptyTitle, { color: t.fg }]}>Start Searching</Text>
+          <Text style={[styles.emptyBody, { color: t.fgMuted }]}>
             Enter a TV show name to search and add to your collection.
           </Text>
         </View>
       )}
 
-      {!isLoading &&
-        debouncedQuery.length >= 2 &&
-        results.length === 0 && (
-          <View style={styles.emptyState}>
-            <Text variant="titleMedium">No Results</Text>
-            <Text
-              variant="bodyMedium"
-              style={{ color: theme.colors.onSurfaceVariant, marginTop: 4 }}
-            >
-              No shows found for "{debouncedQuery}". Try a different search
-              term.
-            </Text>
-          </View>
-        )}
+      {!isLoading && debouncedQuery.length >= 2 && results.length === 0 && (
+        <View style={styles.emptyState}>
+          <Text style={[styles.emptyTitle, { color: t.fg }]}>No Results</Text>
+          <Text style={[styles.emptyBody, { color: t.fgMuted }]}>
+            Nothing found for "{debouncedQuery}".
+          </Text>
+        </View>
+      )}
 
       <FlatList
         data={results}
         keyExtractor={(item) => String(item.id)}
-        renderItem={({ item }) => {
-          const userShow = findUserShow(item.id)
-          return (
-            <Card
-              style={styles.card}
-              onPress={() => router.push(`/shows/${item.id}`)}
-            >
-              <View style={styles.cardRow}>
-                {item.poster_path ? (
-                  <Image
-                    source={{ uri: `${TMDB_IMAGE_BASE}${item.poster_path}` }}
-                    style={styles.poster}
-                  />
-                ) : (
-                  <View
-                    style={[
-                      styles.poster,
-                      { backgroundColor: theme.colors.surfaceVariant },
-                    ]}
-                  />
-                )}
-                <View style={styles.cardInfo}>
-                  <Text variant="titleSmall" numberOfLines={2}>
-                    {item.name}
-                  </Text>
-                  <View style={styles.badgeRow}>
-                    {item.first_air_date && (
-                      <Chip compact style={styles.badge}>
-                        {item.first_air_date.slice(0, 4)}
-                      </Chip>
-                    )}
-                    {item.vote_average > 0 && (
-                      <Chip compact icon="star" style={styles.badge}>
-                        {item.vote_average.toFixed(1)}
-                      </Chip>
-                    )}
-                  </View>
-                  {item.overview ? (
-                    <Text
-                      variant="bodySmall"
-                      numberOfLines={2}
-                      style={{ color: theme.colors.onSurfaceVariant }}
-                    >
-                      {item.overview}
-                    </Text>
-                  ) : null}
-                  <AddButton
-                    show={item}
-                    userShow={userShow}
-                    onAdd={(showId, status) =>
-                      addMutation.mutate({ showId, status })
-                    }
-                    isPending={addMutation.isPending}
-                  />
-                </View>
-              </View>
-            </Card>
-          )
-        }}
+        renderItem={({ item }) => (
+          <SearchResultRow
+            show={item}
+            userShow={findUserShow(item.id)}
+            onAdd={(showId, status) => addMutation.mutate({ showId, status })}
+            isPending={addMutation.isPending}
+          />
+        )}
         contentContainerStyle={styles.list}
         keyboardDismissMode="on-drag"
-        onEndReached={() => {
-          if (hasNextPage && !isFetchingNextPage) fetchNextPage()
-        }}
+        onEndReached={() => { if (hasNextPage && !isFetchingNextPage) fetchNextPage() }}
         onEndReachedThreshold={0.4}
         ListFooterComponent={
-          isFetchingNextPage ? (
-            <ActivityIndicator style={styles.loadingMore} />
-          ) : null
+          isFetchingNextPage ? <ActivityIndicator style={styles.loadingMore} /> : null
         }
       />
     </View>
@@ -307,18 +296,144 @@ export default function SearchScreen() {
 
 const styles = StyleSheet.create({
   container: { flex: 1 },
-  searchbar: { margin: 12 },
-  emptyState: { margin: 24 },
-  list: { padding: 12, gap: 8 },
-  card: { overflow: "hidden" },
-  cardRow: { flexDirection: "row" },
-  poster: { width: 70, height: 105 },
-  cardInfo: { flex: 1, padding: 10, gap: 4, minWidth: 0 },
-  badgeRow: { flexDirection: "row", flexWrap: "wrap", gap: 4 },
-  badge: { alignSelf: "flex-start" },
-  addRow: { flexDirection: "row", gap: 4, marginTop: 4 },
-  addButton: { alignSelf: "flex-start" },
-  chevronButton: { alignSelf: "flex-start", minWidth: 0, paddingHorizontal: 4 },
-  inCollectionChip: { alignSelf: "flex-start", marginTop: 4 },
-  loadingMore: { marginVertical: 16 },
+  header: {
+    paddingHorizontal: 22,
+    paddingBottom: 16,
+  },
+  title: {
+    fontFamily: SERIF,
+    fontSize: 44,
+    letterSpacing: -0.8,
+    lineHeight: 44,
+  },
+  inputWrap: {
+    paddingHorizontal: 22,
+    paddingBottom: 14,
+  },
+  inputContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    borderRadius: 14,
+    borderWidth: 1,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    gap: 10,
+  },
+  searchIcon: {
+    fontSize: 18,
+    lineHeight: 22,
+  },
+  input: {
+    flex: 1,
+    fontSize: 15,
+    padding: 0,
+  },
+  clearBtn: {
+    padding: 4,
+  },
+  clearBtnText: {
+    fontSize: 13,
+  },
+  emptyState: {
+    padding: 24,
+  },
+  emptyTitle: {
+    fontFamily: SERIF,
+    fontSize: 24,
+    letterSpacing: -0.3,
+    marginBottom: 6,
+  },
+  emptyBody: {
+    fontFamily: SANS,
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  list: {
+    paddingHorizontal: 22,
+  },
+  resultRow: {
+    flexDirection: "row",
+    gap: 14,
+    paddingVertical: 16,
+    borderBottomWidth: 1,
+    alignItems: "flex-start",
+  },
+  posterWrap: {
+    position: "relative",
+    flexShrink: 0,
+  },
+  poster: {
+    width: 68,
+    height: 102,
+    borderRadius: 6,
+  },
+  collectionBadge: {
+    position: "absolute",
+    top: -4,
+    right: -4,
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    alignItems: "center",
+    justifyContent: "center",
+    shadowColor: "#000",
+    shadowOpacity: 0.2,
+    shadowRadius: 3,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 3,
+  },
+  collectionBadgeText: {
+    color: "#fff",
+    fontSize: 11,
+    fontFamily: SANS_700,
+  },
+  info: {
+    flex: 1,
+    minWidth: 0,
+    gap: 4,
+  },
+  showTitle: {
+    fontFamily: SERIF,
+    fontSize: 22,
+    letterSpacing: -0.2,
+    lineHeight: 26,
+  },
+  metaRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    flexWrap: "wrap",
+  },
+  metaText: {
+    fontFamily: MONO,
+    fontSize: 11,
+  },
+  metaDot: {
+    width: 2,
+    height: 2,
+    borderRadius: 1,
+  },
+  overview: {
+    fontFamily: SANS,
+    fontSize: 12.5,
+    lineHeight: 18,
+    marginTop: 4,
+  },
+  addBtn: {
+    marginTop: 6,
+    alignSelf: "flex-start",
+    paddingVertical: 7,
+    paddingHorizontal: 14,
+    borderRadius: 999,
+    borderWidth: 1,
+    minWidth: 60,
+    alignItems: "center",
+  },
+  addBtnText: {
+    fontFamily: SANS_600,
+    fontSize: 12.5,
+  },
+  loadingMore: {
+    marginVertical: 16,
+  },
 })

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,25 +1,51 @@
-import React from "react"
+import React, { useEffect } from "react"
 import { useColorScheme } from "react-native"
 import { Stack } from "expo-router"
+import * as SplashScreen from "expo-splash-screen"
 import { QueryClientProvider } from "@tanstack/react-query"
 import { PaperProvider, MD3LightTheme, MD3DarkTheme } from "react-native-paper"
 import { SafeAreaProvider } from "react-native-safe-area-context"
+import {
+  useFonts,
+  InstrumentSerif_400Regular,
+  InstrumentSerif_400Regular_Italic,
+} from "@expo-google-fonts/instrument-serif"
+import {
+  DMSans_400Regular,
+  DMSans_500Medium,
+  DMSans_600SemiBold,
+  DMSans_700Bold,
+} from "@expo-google-fonts/dm-sans"
+import {
+  JetBrainsMono_400Regular,
+  JetBrainsMono_500Medium,
+  JetBrainsMono_600SemiBold,
+} from "@expo-google-fonts/jetbrains-mono"
 import { AuthProvider } from "../lib/auth"
 import { queryClient } from "../lib/queryClient"
 
-// Mirrors the web app's slate + teal palette
+SplashScreen.preventAutoHideAsync()
+
 const lightTheme = {
   ...MD3LightTheme,
   colors: {
     ...MD3LightTheme.colors,
-    primary: "#1a9268",           // teal — hsl(158 65% 36%)
+    primary: "#1a9268",
     onPrimary: "#ffffff",
-    primaryContainer: "#c2f0dc",  // light teal surface
-    onPrimaryContainer: "#00311e",
-    secondary: "#667585",         // muted slate — hsl(215 18% 48%)
+    primaryContainer: "#e6f7f1",
+    onPrimaryContainer: "#0d5c41",
+    secondary: "#5C5B57",
     onSecondary: "#ffffff",
-    secondaryContainer: "#dae3ef",
-    onSecondaryContainer: "#202c38",
+    secondaryContainer: "#F2F1EC",
+    onSecondaryContainer: "#16161A",
+    background: "#FAFAF7",
+    onBackground: "#16161A",
+    surface: "#FFFFFF",
+    onSurface: "#16161A",
+    surfaceVariant: "#F2F1EC",
+    onSurfaceVariant: "#5C5B57",
+    outline: "#E6E4DD",
+    outlineVariant: "#D7D4CB",
   },
 }
 
@@ -27,20 +53,48 @@ const darkTheme = {
   ...MD3DarkTheme,
   colors: {
     ...MD3DarkTheme.colors,
-    primary: "#36c98a",           // lighter teal for dark bg — hsl(158 58% 50%)
+    primary: "#36c98a",
     onPrimary: "#00311e",
-    primaryContainer: "#003d26",  // dark teal surface
-    onPrimaryContainer: "#c2f0dc",
-    secondary: "#9aaebb",         // lighter slate for dark — hsl(215 18% 68%)
-    onSecondary: "#202c38",
-    secondaryContainer: "#3a4756",
-    onSecondaryContainer: "#dae3ef",
+    primaryContainer: "#0d3d28",
+    onPrimaryContainer: "#6de0b0",
+    secondary: "#9C9C95",
+    onSecondary: "#0E0F12",
+    secondaryContainer: "#1C1F24",
+    onSecondaryContainer: "#F4F4F0",
+    background: "#0E0F12",
+    onBackground: "#F4F4F0",
+    surface: "#16181C",
+    onSurface: "#F4F4F0",
+    surfaceVariant: "#1C1F24",
+    onSurfaceVariant: "#9C9C95",
+    outline: "#262A30",
+    outlineVariant: "#3A3F47",
   },
 }
 
 export default function RootLayout() {
   const colorScheme = useColorScheme()
   const theme = colorScheme === "dark" ? darkTheme : lightTheme
+
+  const [fontsLoaded] = useFonts({
+    InstrumentSerif_400Regular,
+    InstrumentSerif_400Regular_Italic,
+    DMSans_400Regular,
+    DMSans_500Medium,
+    DMSans_600SemiBold,
+    DMSans_700Bold,
+    JetBrainsMono_400Regular,
+    JetBrainsMono_500Medium,
+    JetBrainsMono_600SemiBold,
+  })
+
+  useEffect(() => {
+    if (fontsLoaded) {
+      SplashScreen.hideAsync()
+    }
+  }, [fontsLoaded])
+
+  if (!fontsLoaded) return null
 
   return (
     <SafeAreaProvider>

--- a/apps/mobile/app/shows/[id].tsx
+++ b/apps/mobile/app/shows/[id].tsx
@@ -19,7 +19,6 @@ import {
   StatusKey,
   STATUS_LABELS,
   SERIF,
-  SERIF_ITALIC,
   SANS,
   SANS_600,
   SANS_700,
@@ -36,10 +35,10 @@ type ProgressEntry = {
 
 const STATUSES: { value: StatusKey; label: string }[] = [
   { value: "want_to_watch", label: "Want to Watch" },
-  { value: "watching",      label: "Watching" },
-  { value: "caught_up",     label: "Caught Up" },
-  { value: "completed",     label: "Completed" },
-  { value: "stopped",       label: "Stopped" },
+  { value: "watching", label: "Watching" },
+  { value: "caught_up", label: "Caught Up" },
+  { value: "completed", label: "Completed" },
+  { value: "stopped", label: "Stopped" },
 ]
 
 export default function ShowDetailScreen() {
@@ -67,7 +66,10 @@ export default function ShowDetailScreen() {
     enabled: !!id,
   })
 
-  const activeSeason = selectedSeason ?? (seasons?.filter(s => s.season_number > 0).at(-1)?.season_number ?? 1)
+  const activeSeason =
+    selectedSeason ??
+    seasons?.filter((s) => s.season_number > 0).at(-1)?.season_number ??
+    1
 
   const invalidateShow = () => {
     qc.invalidateQueries({ queryKey: ["/api/shows", id] })
@@ -76,14 +78,34 @@ export default function ShowDetailScreen() {
   }
 
   const toggleEpisode = useMutation({
-    mutationFn: ({ seasonNumber, episodeNumber, watched }: { seasonNumber: number; episodeNumber: number; watched: boolean }) =>
-      apiRequest("POST", `/api/shows/${id}/progress`, { seasonNumber, episodeNumber, watched }),
+    mutationFn: ({
+      seasonNumber,
+      episodeNumber,
+      watched,
+    }: {
+      seasonNumber: number
+      episodeNumber: number
+      watched: boolean
+    }) =>
+      apiRequest("POST", `/api/shows/${id}/progress`, {
+        seasonNumber,
+        episodeNumber,
+        watched,
+      }),
     onSuccess: invalidateShow,
   })
 
   const markAllSeason = useMutation({
-    mutationFn: ({ seasonNumber, watched }: { seasonNumber: number; watched: boolean }) =>
-      apiRequest("POST", `/api/shows/${id}/season/${seasonNumber}/mark-all`, { watched }),
+    mutationFn: ({
+      seasonNumber,
+      watched,
+    }: {
+      seasonNumber: number
+      watched: boolean
+    }) =>
+      apiRequest("POST", `/api/shows/${id}/season/${seasonNumber}/mark-all`, {
+        watched,
+      }),
     onSuccess: invalidateShow,
   })
 
@@ -122,9 +144,16 @@ export default function ShowDetailScreen() {
   if (!show) {
     return (
       <View style={[styles.center, { backgroundColor: t.bg }]}>
-        <Text style={{ color: t.fg, fontFamily: SERIF, fontSize: 20 }}>Show not found.</Text>
-        <TouchableOpacity onPress={() => router.back()} style={styles.backFallback}>
-          <Text style={{ color: t.accent, fontFamily: SANS_600 }}>← Go back</Text>
+        <Text style={{ color: t.fg, fontFamily: SERIF, fontSize: 20 }}>
+          Show not found.
+        </Text>
+        <TouchableOpacity
+          onPress={() => router.back()}
+          style={styles.backFallback}
+        >
+          <Text style={{ color: t.accent, fontFamily: SANS_600 }}>
+            ← Go back
+          </Text>
         </TouchableOpacity>
       </View>
     )
@@ -138,28 +167,43 @@ export default function ShowDetailScreen() {
 
   const isInCollection = !!show.userShow
   const currentStatus = show.userShow?.status as StatusKey | undefined
-  const sp = currentStatus ? STATUS_COLORS[currentStatus] : STATUS_COLORS.want_to_watch
+  const sp = currentStatus
+    ? STATUS_COLORS[currentStatus]
+    : STATUS_COLORS.want_to_watch
 
   const watchedSet = new Set(
-    (progress ?? []).filter((p) => p.watched).map((p) => `${p.seasonNumber}x${p.episodeNumber}`)
+    (progress ?? [])
+      .filter((p) => p.watched)
+      .map((p) => `${p.seasonNumber}x${p.episodeNumber}`)
   )
 
   const regularSeasons = seasons?.filter((s) => s.season_number > 0) ?? []
-  const activeSeasonData = regularSeasons.find((s) => s.season_number === activeSeason)
+  const activeSeasonData = regularSeasons.find(
+    (s) => s.season_number === activeSeason
+  )
 
   const progressPct =
-    show.watchedEpisodes != null && show.totalEpisodes != null && show.totalEpisodes > 0
+    show.watchedEpisodes != null &&
+    show.totalEpisodes != null &&
+    show.totalEpisodes > 0
       ? show.watchedEpisodes / show.totalEpisodes
       : 0
 
   const nextEp = show.nextEpisode
 
   return (
-    <ScrollView style={{ backgroundColor: t.bg }} contentContainerStyle={{ paddingBottom: 48 }}>
+    <ScrollView
+      style={{ backgroundColor: t.bg }}
+      contentContainerStyle={{ paddingBottom: 48 }}
+    >
       {/* Cinematic backdrop */}
       <View style={styles.backdropContainer}>
         {backdropUri ? (
-          <ImageBackground source={{ uri: backdropUri }} style={styles.backdrop} resizeMode="cover">
+          <ImageBackground
+            source={{ uri: backdropUri }}
+            style={styles.backdrop}
+            resizeMode="cover"
+          >
             <LinearGradient
               colors={["rgba(0,0,0,0.4)", "transparent", "transparent", t.bg]}
               locations={[0, 0.3, 0.5, 1]}
@@ -172,8 +216,14 @@ export default function ShowDetailScreen() {
               onDismissMore={() => setMoreMenuVisible(false)}
               insets={insets}
               isInCollection={isInCollection}
-              onRemove={() => { removeShow.mutate(); setMoreMenuVisible(false) }}
-              onStatusChange={(s) => { updateStatus.mutate(s); setMoreMenuVisible(false) }}
+              onRemove={() => {
+                removeShow.mutate()
+                setMoreMenuVisible(false)
+              }}
+              onStatusChange={(s) => {
+                updateStatus.mutate(s)
+                setMoreMenuVisible(false)
+              }}
             />
           </ImageBackground>
         ) : (
@@ -185,8 +235,14 @@ export default function ShowDetailScreen() {
               onDismissMore={() => setMoreMenuVisible(false)}
               insets={insets}
               isInCollection={isInCollection}
-              onRemove={() => { removeShow.mutate(); setMoreMenuVisible(false) }}
-              onStatusChange={(s) => { updateStatus.mutate(s); setMoreMenuVisible(false) }}
+              onRemove={() => {
+                removeShow.mutate()
+                setMoreMenuVisible(false)
+              }}
+              onStatusChange={(s) => {
+                updateStatus.mutate(s)
+                setMoreMenuVisible(false)
+              }}
             />
           </View>
         )}
@@ -196,27 +252,37 @@ export default function ShowDetailScreen() {
       <View style={[styles.infoBlock, { marginTop: -100 }]}>
         <View style={styles.chips}>
           {currentStatus && (
-            <View style={[styles.statusChip, { backgroundColor: sp.light.solid }]}>
-              <Text style={styles.statusChipText}>{STATUS_LABELS[currentStatus].toUpperCase()}</Text>
+            <View
+              style={[styles.statusChip, { backgroundColor: sp.light.solid }]}
+            >
+              <Text style={styles.statusChipText}>
+                {STATUS_LABELS[currentStatus].toUpperCase()}
+              </Text>
             </View>
           )}
           {show.firstAirDate && (
             <View style={[styles.darkChip]}>
-              <Text style={styles.darkChipText}>{show.firstAirDate.slice(0, 4)}</Text>
+              <Text style={styles.darkChipText}>
+                {show.firstAirDate.slice(0, 4)}
+              </Text>
             </View>
           )}
         </View>
         <Text style={styles.showTitle}>{show.name}</Text>
         <Text style={styles.showMeta}>
           {show.genres?.join(" · ")}
-          {regularSeasons.length > 0 ? ` · ${regularSeasons.length} season${regularSeasons.length !== 1 ? "s" : ""}` : ""}
+          {regularSeasons.length > 0
+            ? ` · ${regularSeasons.length} season${regularSeasons.length !== 1 ? "s" : ""}`
+            : ""}
         </Text>
       </View>
 
       {/* Overview */}
       {show.overview && (
         <View style={styles.overviewBlock}>
-          <Text style={[styles.overview, { color: t.fgMuted }]}>{show.overview}</Text>
+          <Text style={[styles.overview, { color: t.fgMuted }]}>
+            {show.overview}
+          </Text>
         </View>
       )}
 
@@ -238,73 +304,90 @@ export default function ShowDetailScreen() {
       )}
 
       {/* Progress */}
-      {isInCollection && show.watchedEpisodes != null && show.totalEpisodes != null && (
-        <View style={styles.progressBlock}>
-          <View style={styles.progressHeader}>
-            <Text style={[styles.sectionTitle, { color: t.fg }]}>Progress</Text>
-            <Text style={[styles.progressCount, { color: t.fg }]}>
-              {show.watchedEpisodes}/{show.totalEpisodes} · {Math.round(progressPct * 100)}%
-            </Text>
-          </View>
-          <View style={[styles.progressTrack, { backgroundColor: t.surfaceAlt }]}>
-            <View
-              style={[styles.progressFill, { width: `${progressPct * 100}%` as any, backgroundColor: sp.light.solid }]}
-            />
-          </View>
-          <View style={styles.progressActions}>
-            <TouchableOpacity
-              style={[styles.nextBtn, { backgroundColor: sp.light.solid }]}
-              onPress={() => {
-                if (nextEp) {
-                  toggleEpisode.mutate({
-                    seasonNumber: nextEp.season,
-                    episodeNumber: nextEp.episode,
-                    watched: true,
-                  })
-                }
-              }}
-              disabled={!nextEp || toggleEpisode.isPending}
-              activeOpacity={0.8}
-            >
-              <Text style={styles.nextBtnText}>
-                {nextEp ? `Next: S${nextEp.season} E${nextEp.episode}` : "Up to date"}
+      {isInCollection &&
+        show.watchedEpisodes != null &&
+        show.totalEpisodes != null && (
+          <View style={styles.progressBlock}>
+            <View style={styles.progressHeader}>
+              <Text style={[styles.sectionTitle, { color: t.fg }]}>
+                Progress
               </Text>
-            </TouchableOpacity>
-            <Menu
-              visible={statusMenuVisible}
-              onDismiss={() => setStatusMenuVisible(false)}
-              anchor={
-                <TouchableOpacity
-                  style={[styles.moreBtn, { borderColor: t.border }]}
-                  onPress={() => setStatusMenuVisible(true)}
-                  activeOpacity={0.8}
-                >
-                  <Text style={[styles.moreBtnText, { color: t.fg }]}>···</Text>
-                </TouchableOpacity>
-              }
+              <Text style={[styles.progressCount, { color: t.fg }]}>
+                {show.watchedEpisodes}/{show.totalEpisodes} ·{" "}
+                {Math.round(progressPct * 100)}%
+              </Text>
+            </View>
+            <View
+              style={[styles.progressTrack, { backgroundColor: t.surfaceAlt }]}
             >
-              {STATUSES.map((s) => (
+              <View
+                style={[
+                  styles.progressFill,
+                  {
+                    width: `${progressPct * 100}%` as any,
+                    backgroundColor: sp.light.solid,
+                  },
+                ]}
+              />
+            </View>
+            <View style={styles.progressActions}>
+              <TouchableOpacity
+                style={[styles.nextBtn, { backgroundColor: sp.light.solid }]}
+                onPress={() => {
+                  if (nextEp) {
+                    toggleEpisode.mutate({
+                      seasonNumber: nextEp.season,
+                      episodeNumber: nextEp.episode,
+                      watched: true,
+                    })
+                  }
+                }}
+                disabled={!nextEp || toggleEpisode.isPending}
+                activeOpacity={0.8}
+              >
+                <Text style={styles.nextBtnText}>
+                  {nextEp
+                    ? `Next: S${nextEp.season} E${nextEp.episode}`
+                    : "Up to date"}
+                </Text>
+              </TouchableOpacity>
+              <Menu
+                visible={statusMenuVisible}
+                onDismiss={() => setStatusMenuVisible(false)}
+                anchor={
+                  <TouchableOpacity
+                    style={[styles.moreBtn, { borderColor: t.border }]}
+                    onPress={() => setStatusMenuVisible(true)}
+                    activeOpacity={0.8}
+                  >
+                    <Text style={[styles.moreBtnText, { color: t.fg }]}>
+                      ···
+                    </Text>
+                  </TouchableOpacity>
+                }
+              >
+                {STATUSES.map((s) => (
+                  <Menu.Item
+                    key={s.value}
+                    title={s.label}
+                    onPress={() => {
+                      updateStatus.mutate(s.value)
+                      setStatusMenuVisible(false)
+                    }}
+                  />
+                ))}
                 <Menu.Item
-                  key={s.value}
-                  title={s.label}
+                  title="Remove from collection"
+                  titleStyle={{ color: "#c03030" }}
                   onPress={() => {
-                    updateStatus.mutate(s.value)
+                    removeShow.mutate()
                     setStatusMenuVisible(false)
                   }}
                 />
-              ))}
-              <Menu.Item
-                title="Remove from collection"
-                titleStyle={{ color: "#c03030" }}
-                onPress={() => {
-                  removeShow.mutate()
-                  setStatusMenuVisible(false)
-                }}
-              />
-            </Menu>
+              </Menu>
+            </View>
           </View>
-        </View>
-      )}
+        )}
 
       {/* Episodes */}
       {regularSeasons.length > 0 && (
@@ -312,7 +395,11 @@ export default function ShowDetailScreen() {
           <Text style={[styles.sectionTitle, { color: t.fg }]}>Episodes</Text>
 
           {/* Season pills */}
-          <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.seasonPills}>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.seasonPills}
+          >
             {regularSeasons.map((s) => {
               const isActive = s.season_number === activeSeason
               return (
@@ -328,7 +415,12 @@ export default function ShowDetailScreen() {
                   onPress={() => setSelectedSeason(s.season_number)}
                   activeOpacity={0.7}
                 >
-                  <Text style={[styles.seasonPillText, { color: isActive ? t.bg : t.fgMuted }]}>
+                  <Text
+                    style={[
+                      styles.seasonPillText,
+                      { color: isActive ? t.bg : t.fgMuted },
+                    ]}
+                  >
                     Season {s.season_number}
                   </Text>
                 </TouchableOpacity>
@@ -344,10 +436,14 @@ export default function ShowDetailScreen() {
               </Text>
               <TouchableOpacity
                 onPress={() => {
-                  const isFullyWatched = activeSeasonData.episodes?.every((ep) =>
-                    watchedSet.has(`${ep.season_number}x${ep.episode_number}`)
+                  const isFullyWatched = activeSeasonData.episodes?.every(
+                    (ep) =>
+                      watchedSet.has(`${ep.season_number}x${ep.episode_number}`)
                   )
-                  markAllSeason.mutate({ seasonNumber: activeSeason, watched: !isFullyWatched })
+                  markAllSeason.mutate({
+                    seasonNumber: activeSeason,
+                    watched: !isFullyWatched,
+                  })
                 }}
                 disabled={markAllSeason.isPending}
               >
@@ -360,8 +456,12 @@ export default function ShowDetailScreen() {
 
           {/* Episode rows */}
           {activeSeasonData?.episodes?.map((ep) => {
-            const watched = watchedSet.has(`${ep.season_number}x${ep.episode_number}`)
-            const isCurrentSp = currentStatus ? STATUS_COLORS[currentStatus] : STATUS_COLORS.watching
+            const watched = watchedSet.has(
+              `${ep.season_number}x${ep.episode_number}`
+            )
+            const isCurrentSp = currentStatus
+              ? STATUS_COLORS[currentStatus]
+              : STATUS_COLORS.watching
             return (
               <TouchableOpacity
                 key={`${ep.season_number}x${ep.episode_number}`}
@@ -380,15 +480,21 @@ export default function ShowDetailScreen() {
                   style={[
                     styles.episodeToggle,
                     {
-                      backgroundColor: watched ? isCurrentSp.light.solid : "transparent",
-                      borderColor: watched ? isCurrentSp.light.solid : t.borderStrong,
+                      backgroundColor: watched
+                        ? isCurrentSp.light.solid
+                        : "transparent",
+                      borderColor: watched
+                        ? isCurrentSp.light.solid
+                        : t.borderStrong,
                     },
                   ]}
                 >
                   {watched ? (
                     <Text style={styles.episodeCheck}>✓</Text>
                   ) : (
-                    <Text style={[styles.episodeNum, { color: t.fgMuted }]}>{ep.episode_number}</Text>
+                    <Text style={[styles.episodeNum, { color: t.fgMuted }]}>
+                      {ep.episode_number}
+                    </Text>
                   )}
                 </View>
                 <View style={styles.episodeInfo}>
@@ -436,14 +542,22 @@ function BackdropChrome({
 }) {
   return (
     <View style={[styles.backdropNav, { paddingTop: insets.top + 12 }]}>
-      <TouchableOpacity style={styles.glassBtn} onPress={onBack} activeOpacity={0.8}>
+      <TouchableOpacity
+        style={styles.glassBtn}
+        onPress={onBack}
+        activeOpacity={0.8}
+      >
         <Text style={styles.glassBtnText}>‹</Text>
       </TouchableOpacity>
       <Menu
         visible={moreMenuVisible}
         onDismiss={onDismissMore}
         anchor={
-          <TouchableOpacity style={styles.glassBtn} onPress={onMore} activeOpacity={0.8}>
+          <TouchableOpacity
+            style={styles.glassBtn}
+            onPress={onMore}
+            activeOpacity={0.8}
+          >
             <Text style={styles.glassBtnText}>⋮</Text>
           </TouchableOpacity>
         }

--- a/apps/mobile/app/shows/[id].tsx
+++ b/apps/mobile/app/shows/[id].tsx
@@ -2,28 +2,31 @@ import React, { useState } from "react"
 import {
   ScrollView,
   View,
-  Image,
   StyleSheet,
   TouchableOpacity,
+  ImageBackground,
 } from "react-native"
-import {
-  Text,
-  Button,
-  useTheme,
-  Divider,
-  Menu,
-  ActivityIndicator,
-  ProgressBar,
-  Chip,
-} from "react-native-paper"
+import { Text, Menu, ActivityIndicator } from "react-native-paper"
+import { LinearGradient } from "expo-linear-gradient"
 import { useLocalSearchParams, useRouter } from "expo-router"
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { apiRequest } from "@showtracker/api-client"
 import type { ShowWithProgress, TMDBSeason } from "@showtracker/shared"
-import { EpisodeRow } from "../../components/EpisodeRow"
-import { StatusBadge } from "../../components/StatusBadge"
+import {
+  useAppTheme,
+  STATUS_COLORS,
+  StatusKey,
+  STATUS_LABELS,
+  SERIF,
+  SERIF_ITALIC,
+  SANS,
+  SANS_600,
+  SANS_700,
+  MONO,
+} from "../../lib/theme"
 
-const TMDB_IMAGE_BASE = "https://image.tmdb.org/t/p/w500"
+const TMDB_W780 = "https://image.tmdb.org/t/p/w780"
 
 type ProgressEntry = {
   seasonNumber: number
@@ -31,21 +34,23 @@ type ProgressEntry = {
   watched: boolean
 }
 
-const STATUSES = [
+const STATUSES: { value: StatusKey; label: string }[] = [
   { value: "want_to_watch", label: "Want to Watch" },
-  { value: "watching", label: "Watching" },
-  { value: "caught_up", label: "Caught Up" },
-  { value: "completed", label: "Completed" },
-  { value: "stopped", label: "Stopped" },
+  { value: "watching",      label: "Watching" },
+  { value: "caught_up",     label: "Caught Up" },
+  { value: "completed",     label: "Completed" },
+  { value: "stopped",       label: "Stopped" },
 ]
 
 export default function ShowDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>()
   const router = useRouter()
-  const theme = useTheme()
+  const t = useAppTheme()
+  const insets = useSafeAreaInsets()
   const qc = useQueryClient()
-  const [expandedSeasons, setExpandedSeasons] = useState<Set<number>>(new Set())
+  const [selectedSeason, setSelectedSeason] = useState<number | null>(null)
   const [statusMenuVisible, setStatusMenuVisible] = useState(false)
+  const [moreMenuVisible, setMoreMenuVisible] = useState(false)
 
   const { data: show, isLoading } = useQuery<ShowWithProgress>({
     queryKey: ["/api/shows", id],
@@ -62,6 +67,8 @@ export default function ShowDetailScreen() {
     enabled: !!id,
   })
 
+  const activeSeason = selectedSeason ?? (seasons?.filter(s => s.season_number > 0).at(-1)?.season_number ?? 1)
+
   const invalidateShow = () => {
     qc.invalidateQueries({ queryKey: ["/api/shows", id] })
     qc.invalidateQueries({ queryKey: ["/api/shows", id, "progress"] })
@@ -69,34 +76,14 @@ export default function ShowDetailScreen() {
   }
 
   const toggleEpisode = useMutation({
-    mutationFn: ({
-      seasonNumber,
-      episodeNumber,
-      watched,
-    }: {
-      seasonNumber: number
-      episodeNumber: number
-      watched: boolean
-    }) =>
-      apiRequest("POST", `/api/shows/${id}/progress`, {
-        seasonNumber,
-        episodeNumber,
-        watched,
-      }),
+    mutationFn: ({ seasonNumber, episodeNumber, watched }: { seasonNumber: number; episodeNumber: number; watched: boolean }) =>
+      apiRequest("POST", `/api/shows/${id}/progress`, { seasonNumber, episodeNumber, watched }),
     onSuccess: invalidateShow,
   })
 
   const markAllSeason = useMutation({
-    mutationFn: ({
-      seasonNumber,
-      watched,
-    }: {
-      seasonNumber: number
-      watched: boolean
-    }) =>
-      apiRequest("POST", `/api/shows/${id}/season/${seasonNumber}/mark-all`, {
-        watched,
-      }),
+    mutationFn: ({ seasonNumber, watched }: { seasonNumber: number; watched: boolean }) =>
+      apiRequest("POST", `/api/shows/${id}/season/${seasonNumber}/mark-all`, { watched }),
     onSuccess: invalidateShow,
   })
 
@@ -120,265 +107,364 @@ export default function ShowDetailScreen() {
 
   const updateStatus = useMutation({
     mutationFn: (status: string) =>
-      apiRequest("POST", "/api/user/shows", {
-        showId: Number(id),
-        status,
-      }),
+      apiRequest("POST", "/api/user/shows", { showId: Number(id), status }),
     onSuccess: invalidateShow,
   })
 
   if (isLoading) {
     return (
-      <View style={styles.center}>
-        <ActivityIndicator size="large" color={theme.colors.primary} />
+      <View style={[styles.center, { backgroundColor: t.bg }]}>
+        <ActivityIndicator size="large" color={t.accent} />
       </View>
     )
   }
 
   if (!show) {
     return (
-      <View style={styles.center}>
-        <Text>Show not found.</Text>
-        <Button onPress={() => router.back()}>Go back</Button>
+      <View style={[styles.center, { backgroundColor: t.bg }]}>
+        <Text style={{ color: t.fg, fontFamily: SERIF, fontSize: 20 }}>Show not found.</Text>
+        <TouchableOpacity onPress={() => router.back()} style={styles.backFallback}>
+          <Text style={{ color: t.accent, fontFamily: SANS_600 }}>← Go back</Text>
+        </TouchableOpacity>
       </View>
     )
   }
 
   const backdropUri = show.backdropPath
-    ? `${TMDB_IMAGE_BASE}${show.backdropPath}`
+    ? `${TMDB_W780}${show.backdropPath}`
     : show.posterPath
-      ? `${TMDB_IMAGE_BASE}${show.posterPath}`
+      ? `${TMDB_W780}${show.posterPath}`
       : null
 
   const isInCollection = !!show.userShow
-  const currentStatus = show.userShow?.status
+  const currentStatus = show.userShow?.status as StatusKey | undefined
+  const sp = currentStatus ? STATUS_COLORS[currentStatus] : STATUS_COLORS.want_to_watch
 
   const watchedSet = new Set(
-    (progress ?? [])
-      .filter((p) => p.watched)
-      .map((p) => `${p.seasonNumber}x${p.episodeNumber}`)
+    (progress ?? []).filter((p) => p.watched).map((p) => `${p.seasonNumber}x${p.episodeNumber}`)
   )
 
-  const toggleSeason = (seasonNumber: number) => {
-    setExpandedSeasons((prev) => {
-      const next = new Set(prev)
-      if (next.has(seasonNumber)) next.delete(seasonNumber)
-      else next.add(seasonNumber)
-      return next
-    })
-  }
+  const regularSeasons = seasons?.filter((s) => s.season_number > 0) ?? []
+  const activeSeasonData = regularSeasons.find((s) => s.season_number === activeSeason)
 
-  const isSeasonFullyWatched = (season: TMDBSeason) => {
-    if (!season.episodes) return false
-    return season.episodes.every((ep) =>
-      watchedSet.has(`${ep.season_number}x${ep.episode_number}`)
-    )
-  }
+  const progressPct =
+    show.watchedEpisodes != null && show.totalEpisodes != null && show.totalEpisodes > 0
+      ? show.watchedEpisodes / show.totalEpisodes
+      : 0
+
+  const nextEp = show.nextEpisode
 
   return (
-    <ScrollView style={{ backgroundColor: theme.colors.background }}>
-      {backdropUri && (
-        <Image source={{ uri: backdropUri }} style={styles.backdrop} />
-      )}
-
-      <View style={styles.header}>
-        <Button
-          icon="arrow-left"
-          onPress={() => router.back()}
-          style={styles.backButton}
-          compact
-        >
-          Back
-        </Button>
-        <Text variant="headlineSmall" style={styles.title}>
-          {show.name}
-        </Text>
-        {show.firstAirDate && (
-          <Text
-            variant="bodyMedium"
-            style={{ color: theme.colors.onSurfaceVariant }}
-          >
-            {show.firstAirDate.slice(0, 4)}
-            {show.status && ` · ${show.status}`}
-          </Text>
-        )}
-        {show.genres && show.genres.length > 0 && (
-          <View style={styles.genres}>
-            {show.genres.map((g) => (
-              <Chip key={g} compact style={styles.genreChip}>
-                {g}
-              </Chip>
-            ))}
-          </View>
-        )}
-        {show.overview && (
-          <Text
-            variant="bodyMedium"
-            style={{ color: theme.colors.onSurfaceVariant, marginTop: 8 }}
-          >
-            {show.overview}
-          </Text>
-        )}
-      </View>
-
-      <Divider />
-
-      <View style={styles.actions}>
-        {isInCollection ? (
-          <View style={styles.actionRow}>
-            <View style={styles.statusRow}>
-              {currentStatus && (
-                <StatusBadge status={currentStatus} variant="detail" />
-              )}
-              <Menu
-                visible={statusMenuVisible}
-                onDismiss={() => setStatusMenuVisible(false)}
-                anchor={
-                  <Button
-                    mode="outlined"
-                    compact
-                    onPress={() => setStatusMenuVisible(true)}
-                  >
-                    Change Status
-                  </Button>
-                }
-              >
-                {STATUSES.map((s) => (
-                  <Menu.Item
-                    key={s.value}
-                    title={s.label}
-                    onPress={() => {
-                      updateStatus.mutate(s.value)
-                      setStatusMenuVisible(false)
-                    }}
-                  />
-                ))}
-              </Menu>
-              <Button
-                mode="outlined"
-                compact
-                textColor={theme.colors.error}
-                onPress={() => removeShow.mutate()}
-                loading={removeShow.isPending}
-              >
-                Remove
-              </Button>
-            </View>
-          </View>
+    <ScrollView style={{ backgroundColor: t.bg }} contentContainerStyle={{ paddingBottom: 48 }}>
+      {/* Cinematic backdrop */}
+      <View style={styles.backdropContainer}>
+        {backdropUri ? (
+          <ImageBackground source={{ uri: backdropUri }} style={styles.backdrop} resizeMode="cover">
+            <LinearGradient
+              colors={["rgba(0,0,0,0.4)", "transparent", "transparent", t.bg]}
+              locations={[0, 0.3, 0.5, 1]}
+              style={StyleSheet.absoluteFill}
+            />
+            <BackdropChrome
+              onBack={() => router.back()}
+              onMore={() => setMoreMenuVisible(true)}
+              moreMenuVisible={moreMenuVisible}
+              onDismissMore={() => setMoreMenuVisible(false)}
+              insets={insets}
+              isInCollection={isInCollection}
+              onRemove={() => { removeShow.mutate(); setMoreMenuVisible(false) }}
+              onStatusChange={(s) => { updateStatus.mutate(s); setMoreMenuVisible(false) }}
+            />
+          </ImageBackground>
         ) : (
-          <Button
-            mode="contained"
-            onPress={() => addShow.mutate("want_to_watch")}
-            loading={addShow.isPending}
-          >
-            Add to Collection
-          </Button>
-        )}
-
-        {show.watchedEpisodes != null && show.totalEpisodes != null && (
-          <View style={styles.progressSection}>
-            <Text
-              variant="bodySmall"
-              style={{ color: theme.colors.onSurfaceVariant }}
-            >
-              {show.watchedEpisodes} / {show.totalEpisodes} episodes watched
-            </Text>
-            <ProgressBar
-              progress={
-                show.totalEpisodes > 0
-                  ? show.watchedEpisodes / show.totalEpisodes
-                  : 0
-              }
-              color={theme.colors.primary}
-              style={styles.progressBar}
+          <View style={[styles.backdrop, { backgroundColor: t.surfaceAlt }]}>
+            <BackdropChrome
+              onBack={() => router.back()}
+              onMore={() => setMoreMenuVisible(true)}
+              moreMenuVisible={moreMenuVisible}
+              onDismissMore={() => setMoreMenuVisible(false)}
+              insets={insets}
+              isInCollection={isInCollection}
+              onRemove={() => { removeShow.mutate(); setMoreMenuVisible(false) }}
+              onStatusChange={(s) => { updateStatus.mutate(s); setMoreMenuVisible(false) }}
             />
           </View>
         )}
       </View>
 
-      <Divider />
+      {/* Pulled-up info block */}
+      <View style={[styles.infoBlock, { marginTop: -100 }]}>
+        <View style={styles.chips}>
+          {currentStatus && (
+            <View style={[styles.statusChip, { backgroundColor: sp.light.solid }]}>
+              <Text style={styles.statusChipText}>{STATUS_LABELS[currentStatus].toUpperCase()}</Text>
+            </View>
+          )}
+          {show.firstAirDate && (
+            <View style={[styles.darkChip]}>
+              <Text style={styles.darkChipText}>{show.firstAirDate.slice(0, 4)}</Text>
+            </View>
+          )}
+        </View>
+        <Text style={styles.showTitle}>{show.name}</Text>
+        <Text style={styles.showMeta}>
+          {show.genres?.join(" · ")}
+          {regularSeasons.length > 0 ? ` · ${regularSeasons.length} season${regularSeasons.length !== 1 ? "s" : ""}` : ""}
+        </Text>
+      </View>
 
-      {seasons && seasons.length > 0 && (
-        <View style={styles.seasons}>
-          <Text variant="titleMedium" style={styles.seasonsTitle}>
-            Seasons
-          </Text>
-          {seasons
-            .filter((s) => s.season_number > 0)
-            .map((season) => {
-              const isExpanded = expandedSeasons.has(season.season_number)
-              const fullyWatched = isSeasonFullyWatched(season)
+      {/* Overview */}
+      {show.overview && (
+        <View style={styles.overviewBlock}>
+          <Text style={[styles.overview, { color: t.fgMuted }]}>{show.overview}</Text>
+        </View>
+      )}
 
+      {/* Add to collection (if not in) */}
+      {!isInCollection && (
+        <View style={styles.actionBlock}>
+          <TouchableOpacity
+            style={[styles.addBtn, { backgroundColor: t.accent }]}
+            onPress={() => addShow.mutate("want_to_watch")}
+            activeOpacity={0.8}
+          >
+            {addShow.isPending ? (
+              <ActivityIndicator size="small" color="#fff" />
+            ) : (
+              <Text style={styles.addBtnText}>Add to Collection</Text>
+            )}
+          </TouchableOpacity>
+        </View>
+      )}
+
+      {/* Progress */}
+      {isInCollection && show.watchedEpisodes != null && show.totalEpisodes != null && (
+        <View style={styles.progressBlock}>
+          <View style={styles.progressHeader}>
+            <Text style={[styles.sectionTitle, { color: t.fg }]}>Progress</Text>
+            <Text style={[styles.progressCount, { color: t.fg }]}>
+              {show.watchedEpisodes}/{show.totalEpisodes} · {Math.round(progressPct * 100)}%
+            </Text>
+          </View>
+          <View style={[styles.progressTrack, { backgroundColor: t.surfaceAlt }]}>
+            <View
+              style={[styles.progressFill, { width: `${progressPct * 100}%` as any, backgroundColor: sp.light.solid }]}
+            />
+          </View>
+          <View style={styles.progressActions}>
+            <TouchableOpacity
+              style={[styles.nextBtn, { backgroundColor: sp.light.solid }]}
+              onPress={() => {
+                if (nextEp) {
+                  toggleEpisode.mutate({
+                    seasonNumber: nextEp.season,
+                    episodeNumber: nextEp.episode,
+                    watched: true,
+                  })
+                }
+              }}
+              disabled={!nextEp || toggleEpisode.isPending}
+              activeOpacity={0.8}
+            >
+              <Text style={styles.nextBtnText}>
+                {nextEp ? `Next: S${nextEp.season} E${nextEp.episode}` : "Up to date"}
+              </Text>
+            </TouchableOpacity>
+            <Menu
+              visible={statusMenuVisible}
+              onDismiss={() => setStatusMenuVisible(false)}
+              anchor={
+                <TouchableOpacity
+                  style={[styles.moreBtn, { borderColor: t.border }]}
+                  onPress={() => setStatusMenuVisible(true)}
+                  activeOpacity={0.8}
+                >
+                  <Text style={[styles.moreBtnText, { color: t.fg }]}>···</Text>
+                </TouchableOpacity>
+              }
+            >
+              {STATUSES.map((s) => (
+                <Menu.Item
+                  key={s.value}
+                  title={s.label}
+                  onPress={() => {
+                    updateStatus.mutate(s.value)
+                    setStatusMenuVisible(false)
+                  }}
+                />
+              ))}
+              <Menu.Item
+                title="Remove from collection"
+                titleStyle={{ color: "#c03030" }}
+                onPress={() => {
+                  removeShow.mutate()
+                  setStatusMenuVisible(false)
+                }}
+              />
+            </Menu>
+          </View>
+        </View>
+      )}
+
+      {/* Episodes */}
+      {regularSeasons.length > 0 && (
+        <View style={styles.episodesBlock}>
+          <Text style={[styles.sectionTitle, { color: t.fg }]}>Episodes</Text>
+
+          {/* Season pills */}
+          <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.seasonPills}>
+            {regularSeasons.map((s) => {
+              const isActive = s.season_number === activeSeason
               return (
-                <View key={season.season_number} style={styles.seasonBlock}>
-                  <TouchableOpacity
-                    style={[
-                      styles.seasonHeader,
-                      { backgroundColor: theme.colors.surfaceVariant },
-                    ]}
-                    onPress={() => toggleSeason(season.season_number)}
-                  >
-                    <Text variant="titleSmall" style={styles.seasonTitle}>
-                      {season.name ?? `Season ${season.season_number}`}
-                      {season.episode_count
-                        ? ` (${season.episode_count} eps)`
-                        : ""}
-                    </Text>
-                    <View style={styles.seasonActions}>
-                      <Button
-                        mode={fullyWatched ? "contained-tonal" : "outlined"}
-                        compact
-                        onPress={() =>
-                          markAllSeason.mutate({
-                            seasonNumber: season.season_number,
-                            watched: !fullyWatched,
-                          })
-                        }
-                        loading={markAllSeason.isPending}
-                      >
-                        {fullyWatched ? "Unmark All" : "Mark All"}
-                      </Button>
-                      <Text
-                        variant="bodySmall"
-                        style={{ color: theme.colors.onSurfaceVariant }}
-                      >
-                        {isExpanded ? "▲" : "▼"}
-                      </Text>
-                    </View>
-                  </TouchableOpacity>
-
-                  {isExpanded && season.episodes && (
-                    <View style={styles.episodeList}>
-                      {season.episodes.map((ep) => {
-                        const watched = watchedSet.has(
-                          `${ep.season_number}x${ep.episode_number}`
-                        )
-                        return (
-                          <EpisodeRow
-                            key={`${ep.season_number}x${ep.episode_number}`}
-                            episodeNumber={ep.episode_number}
-                            name={ep.name}
-                            airDate={ep.air_date}
-                            watched={watched}
-                            onToggle={() =>
-                              toggleEpisode.mutate({
-                                seasonNumber: ep.season_number,
-                                episodeNumber: ep.episode_number,
-                                watched: !watched,
-                              })
-                            }
-                            disabled={toggleEpisode.isPending}
-                          />
-                        )
-                      })}
-                    </View>
-                  )}
-                </View>
+                <TouchableOpacity
+                  key={s.season_number}
+                  style={[
+                    styles.seasonPill,
+                    {
+                      backgroundColor: isActive ? t.fg : "transparent",
+                      borderColor: isActive ? t.fg : t.border,
+                    },
+                  ]}
+                  onPress={() => setSelectedSeason(s.season_number)}
+                  activeOpacity={0.7}
+                >
+                  <Text style={[styles.seasonPillText, { color: isActive ? t.bg : t.fgMuted }]}>
+                    Season {s.season_number}
+                  </Text>
+                </TouchableOpacity>
               )
             })}
+          </ScrollView>
+
+          {/* Mark all row */}
+          {activeSeasonData && (
+            <View style={[styles.markAllRow, { borderBottomColor: t.border }]}>
+              <Text style={[styles.markAllSeasonName, { color: t.fg }]}>
+                {activeSeasonData.name ?? `Season ${activeSeason}`}
+              </Text>
+              <TouchableOpacity
+                onPress={() => {
+                  const isFullyWatched = activeSeasonData.episodes?.every((ep) =>
+                    watchedSet.has(`${ep.season_number}x${ep.episode_number}`)
+                  )
+                  markAllSeason.mutate({ seasonNumber: activeSeason, watched: !isFullyWatched })
+                }}
+                disabled={markAllSeason.isPending}
+              >
+                <Text style={[styles.markAllText, { color: t.accent }]}>
+                  {markAllSeason.isPending ? "…" : "Mark All"}
+                </Text>
+              </TouchableOpacity>
+            </View>
+          )}
+
+          {/* Episode rows */}
+          {activeSeasonData?.episodes?.map((ep) => {
+            const watched = watchedSet.has(`${ep.season_number}x${ep.episode_number}`)
+            const isCurrentSp = currentStatus ? STATUS_COLORS[currentStatus] : STATUS_COLORS.watching
+            return (
+              <TouchableOpacity
+                key={`${ep.season_number}x${ep.episode_number}`}
+                style={[styles.episodeRow, { borderBottomColor: t.border }]}
+                onPress={() =>
+                  toggleEpisode.mutate({
+                    seasonNumber: ep.season_number,
+                    episodeNumber: ep.episode_number,
+                    watched: !watched,
+                  })
+                }
+                disabled={toggleEpisode.isPending}
+                activeOpacity={0.7}
+              >
+                <View
+                  style={[
+                    styles.episodeToggle,
+                    {
+                      backgroundColor: watched ? isCurrentSp.light.solid : "transparent",
+                      borderColor: watched ? isCurrentSp.light.solid : t.borderStrong,
+                    },
+                  ]}
+                >
+                  {watched ? (
+                    <Text style={styles.episodeCheck}>✓</Text>
+                  ) : (
+                    <Text style={[styles.episodeNum, { color: t.fgMuted }]}>{ep.episode_number}</Text>
+                  )}
+                </View>
+                <View style={styles.episodeInfo}>
+                  <Text
+                    style={[
+                      styles.episodeName,
+                      { color: watched ? t.fgMuted : t.fg },
+                    ]}
+                    numberOfLines={1}
+                  >
+                    {ep.name}
+                  </Text>
+                  <Text style={[styles.episodeMeta, { color: t.fgFaint }]}>
+                    S{ep.season_number} · E{ep.episode_number}
+                    {ep.air_date ? `  ·  ${ep.air_date}` : ""}
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            )
+          })}
         </View>
       )}
     </ScrollView>
+  )
+}
+
+function BackdropChrome({
+  onBack,
+  onMore,
+  moreMenuVisible,
+  onDismissMore,
+  insets,
+  isInCollection,
+  onRemove,
+  onStatusChange,
+}: {
+  onBack: () => void
+  onMore: () => void
+  moreMenuVisible: boolean
+  onDismissMore: () => void
+  insets: { top: number }
+  isInCollection: boolean
+  onRemove: () => void
+  onStatusChange: (s: string) => void
+}) {
+  return (
+    <View style={[styles.backdropNav, { paddingTop: insets.top + 12 }]}>
+      <TouchableOpacity style={styles.glassBtn} onPress={onBack} activeOpacity={0.8}>
+        <Text style={styles.glassBtnText}>‹</Text>
+      </TouchableOpacity>
+      <Menu
+        visible={moreMenuVisible}
+        onDismiss={onDismissMore}
+        anchor={
+          <TouchableOpacity style={styles.glassBtn} onPress={onMore} activeOpacity={0.8}>
+            <Text style={styles.glassBtnText}>⋮</Text>
+          </TouchableOpacity>
+        }
+      >
+        {isInCollection &&
+          STATUSES.map((s) => (
+            <Menu.Item
+              key={s.value}
+              title={s.label}
+              onPress={() => onStatusChange(s.value)}
+            />
+          ))}
+        {isInCollection && (
+          <Menu.Item
+            title="Remove from collection"
+            titleStyle={{ color: "#c03030" }}
+            onPress={onRemove}
+          />
+        )}
+      </Menu>
+    </View>
   )
 }
 
@@ -389,77 +475,242 @@ const styles = StyleSheet.create({
     alignItems: "center",
     gap: 16,
   },
+  backFallback: {
+    marginTop: 8,
+  },
+  backdropContainer: {
+    height: 460,
+  },
   backdrop: {
     width: "100%",
-    height: 200,
-    resizeMode: "cover",
+    height: 460,
+    justifyContent: "space-between",
   },
-  header: {
-    padding: 16,
-    gap: 6,
-  },
-  backButton: {
-    alignSelf: "flex-start",
-    marginBottom: 4,
-  },
-  title: {
-    fontWeight: "bold",
-  },
-  genres: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    gap: 6,
-    marginTop: 4,
-  },
-  genreChip: {},
-  actions: {
-    padding: 16,
-    gap: 12,
-  },
-  actionRow: {
-    gap: 12,
-  },
-  statusRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 8,
-    flexWrap: "wrap",
-  },
-  progressSection: {
-    gap: 4,
-  },
-  progressBar: {
-    height: 6,
-    borderRadius: 3,
-  },
-  seasons: {
-    padding: 16,
-    gap: 12,
-  },
-  seasonsTitle: {
-    fontWeight: "600",
-  },
-  seasonBlock: {
-    borderRadius: 8,
-    overflow: "hidden",
-  },
-  seasonHeader: {
+  backdropNav: {
     flexDirection: "row",
     justifyContent: "space-between",
+    paddingHorizontal: 16,
+  },
+  glassBtn: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: "rgba(255,255,255,0.15)",
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.2)",
     alignItems: "center",
-    padding: 12,
+    justifyContent: "center",
+  },
+  glassBtnText: {
+    color: "#fff",
+    fontSize: 20,
+    fontFamily: SANS_600,
+    lineHeight: 24,
+  },
+  infoBlock: {
+    paddingHorizontal: 22,
+    position: "relative",
+  },
+  chips: {
+    flexDirection: "row",
     gap: 8,
+    marginBottom: 12,
   },
-  seasonTitle: {
+  statusChip: {
+    paddingHorizontal: 9,
+    paddingVertical: 4,
+    borderRadius: 999,
+  },
+  statusChipText: {
+    fontFamily: SANS_700,
+    fontSize: 10.5,
+    color: "#fff",
+    letterSpacing: 0.5,
+  },
+  darkChip: {
+    paddingHorizontal: 9,
+    paddingVertical: 4,
+    borderRadius: 999,
+    backgroundColor: "rgba(0,0,0,0.6)",
+  },
+  darkChipText: {
+    fontFamily: MONO,
+    fontSize: 10.5,
+    color: "#fff",
+  },
+  showTitle: {
+    fontFamily: SERIF,
+    fontSize: 44,
+    color: "#fff",
+    letterSpacing: -0.8,
+    lineHeight: 48,
+    textShadowColor: "rgba(0,0,0,0.4)",
+    textShadowOffset: { width: 0, height: 2 },
+    textShadowRadius: 8,
+  },
+  showMeta: {
+    fontFamily: SANS,
+    fontSize: 13,
+    color: "rgba(255,255,255,0.85)",
+    marginTop: 4,
+    textShadowColor: "rgba(0,0,0,0.5)",
+    textShadowOffset: { width: 0, height: 1 },
+    textShadowRadius: 4,
+  },
+  overviewBlock: {
+    paddingHorizontal: 22,
+    marginTop: 24,
+  },
+  overview: {
+    fontFamily: SANS,
+    fontSize: 14,
+    lineHeight: 22,
+  },
+  actionBlock: {
+    paddingHorizontal: 22,
+    marginTop: 20,
+  },
+  addBtn: {
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: "center",
+  },
+  addBtnText: {
+    fontFamily: SANS_700,
+    fontSize: 14,
+    color: "#fff",
+  },
+  progressBlock: {
+    paddingHorizontal: 22,
+    marginTop: 20,
+  },
+  progressHeader: {
+    flexDirection: "row",
+    alignItems: "baseline",
+    justifyContent: "space-between",
+    marginBottom: 10,
+  },
+  sectionTitle: {
+    fontFamily: SERIF,
+    fontSize: 24,
+    letterSpacing: -0.3,
+  },
+  progressCount: {
+    fontFamily: MONO,
+    fontSize: 13,
+  },
+  progressTrack: {
+    height: 5,
+    borderRadius: 999,
+    overflow: "hidden",
+  },
+  progressFill: {
+    height: "100%",
+    borderRadius: 999,
+  },
+  progressActions: {
+    flexDirection: "row",
+    gap: 8,
+    marginTop: 14,
+  },
+  nextBtn: {
     flex: 1,
-    fontWeight: "500",
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    borderRadius: 12,
+    alignItems: "center",
   },
-  seasonActions: {
+  nextBtnText: {
+    fontFamily: SANS_700,
+    fontSize: 13.5,
+    color: "#fff",
+    letterSpacing: -0.1,
+  },
+  moreBtn: {
+    paddingVertical: 12,
+    paddingHorizontal: 18,
+    borderRadius: 12,
+    borderWidth: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  moreBtnText: {
+    fontFamily: SANS_600,
+    fontSize: 14,
+    letterSpacing: 2,
+  },
+  episodesBlock: {
+    paddingHorizontal: 22,
+    marginTop: 24,
+  },
+  seasonPills: {
+    gap: 8,
+    paddingTop: 12,
+    paddingBottom: 14,
+  },
+  seasonPill: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 999,
+    borderWidth: 1,
+  },
+  seasonPillText: {
+    fontFamily: SANS_600,
+    fontSize: 12,
+  },
+  markAllRow: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 8,
+    justifyContent: "space-between",
+    paddingBottom: 12,
+    marginBottom: 4,
+    borderBottomWidth: 1,
   },
-  episodeList: {
-    backgroundColor: "transparent",
+  markAllSeasonName: {
+    fontFamily: SANS_600,
+    fontSize: 14,
+  },
+  markAllText: {
+    fontFamily: SANS_600,
+    fontSize: 13,
+  },
+  episodeRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 14,
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+  },
+  episodeToggle: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    borderWidth: 1.5,
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+  },
+  episodeCheck: {
+    color: "#fff",
+    fontSize: 13,
+    fontFamily: SANS_700,
+  },
+  episodeNum: {
+    fontFamily: MONO,
+    fontSize: 11,
+  },
+  episodeInfo: {
+    flex: 1,
+    minWidth: 0,
+  },
+  episodeName: {
+    fontFamily: SANS,
+    fontSize: 14.5,
+    letterSpacing: -0.1,
+  },
+  episodeMeta: {
+    fontFamily: MONO,
+    fontSize: 11.5,
+    marginTop: 2,
   },
 })

--- a/apps/mobile/components/PosterGrid.tsx
+++ b/apps/mobile/components/PosterGrid.tsx
@@ -1,0 +1,288 @@
+import React from "react"
+import {
+  FlatList,
+  View,
+  Image,
+  TouchableOpacity,
+  StyleSheet,
+  Dimensions,
+  Text,
+  Animated,
+} from "react-native"
+import { useRouter } from "expo-router"
+import type { ShowWithProgress } from "@showtracker/shared"
+import { useAppTheme, STATUS_COLORS, StatusKey, SERIF_ITALIC, SANS, SANS_600, SANS_700, MONO } from "../lib/theme"
+
+const TMDB_W342 = "https://image.tmdb.org/t/p/w342"
+const SCREEN_WIDTH = Dimensions.get("window").width
+const POSTER_WIDTH = Math.floor((SCREEN_WIDTH - 22 * 2 - 18) / 2)
+const POSTER_HEIGHT = Math.floor(POSTER_WIDTH * 1.5)
+
+type Props = {
+  shows: ShowWithProgress[] | undefined
+  isLoading: boolean
+  status: StatusKey
+  emptyMessage?: string
+  onEndReached?: () => void
+}
+
+function SkeletonCard() {
+  const t = useAppTheme()
+  return (
+    <View style={[styles.cell, { width: POSTER_WIDTH }]}>
+      <View style={[styles.posterSkeleton, { backgroundColor: t.surfaceAlt, width: POSTER_WIDTH, height: POSTER_HEIGHT }]} />
+      <View style={[styles.skelLine, { backgroundColor: t.surfaceAlt, width: "80%", marginTop: 10 }]} />
+      <View style={[styles.skelLineSmall, { backgroundColor: t.surfaceAlt, width: "50%" }]} />
+    </View>
+  )
+}
+
+function EmptyState({ status, t }: { status: StatusKey; t: ReturnType<typeof useAppTheme> }) {
+  const router = useRouter()
+  const sp = STATUS_COLORS[status]
+
+  return (
+    <View style={styles.emptyCenter}>
+      <View style={styles.ghostPosters}>
+        {[0.5, 0.7, 0.5].map((opacity, i) => (
+          <View
+            key={i}
+            style={[
+              styles.ghostPoster,
+              { borderColor: t.borderStrong, opacity, width: POSTER_WIDTH * 0.52, height: POSTER_HEIGHT * 0.52 },
+            ]}
+          />
+        ))}
+      </View>
+      <Text style={[styles.emptyTitle, { color: t.fg }]}>Nothing here yet</Text>
+      <Text style={[styles.emptyBody, { color: t.fgMuted }]}>
+        Add shows to start tracking your watch history.
+      </Text>
+      <TouchableOpacity
+        style={[styles.emptyBtn, { backgroundColor: t.fg }]}
+        onPress={() => router.push("/(tabs)/search")}
+        activeOpacity={0.8}
+      >
+        <Text style={[styles.emptyBtnText, { color: t.bg }]}>Browse Search →</Text>
+      </TouchableOpacity>
+    </View>
+  )
+}
+
+export function PosterGrid({ shows, isLoading, status, onEndReached }: Props) {
+  const t = useAppTheme()
+  const router = useRouter()
+  const sp = STATUS_COLORS[status]
+  const solidColor = sp.light.solid
+
+  if (isLoading) {
+    return (
+      <View style={styles.grid}>
+        {[1, 2, 3, 4].map((i) => <SkeletonCard key={i} />)}
+      </View>
+    )
+  }
+
+  if (!shows || shows.length === 0) {
+    return <EmptyState status={status} t={t} />
+  }
+
+  return (
+    <FlatList
+      data={shows}
+      keyExtractor={(item) => String(item.id)}
+      numColumns={2}
+      columnWrapperStyle={styles.row}
+      contentContainerStyle={styles.listContent}
+      onEndReached={onEndReached}
+      onEndReachedThreshold={0.3}
+      renderItem={({ item: show }) => {
+        const posterUri = show.posterPath ? `${TMDB_W342}${show.posterPath}` : null
+        const progress =
+          show.watchedEpisodes != null && show.totalEpisodes != null && show.totalEpisodes > 0
+            ? show.watchedEpisodes / show.totalEpisodes
+            : null
+        const hasProgress = (show.watchedEpisodes ?? 0) > 0
+
+        return (
+          <TouchableOpacity
+            style={[styles.cell, { width: POSTER_WIDTH }]}
+            onPress={() => router.push(`/shows/${show.id}`)}
+            activeOpacity={0.8}
+          >
+            <View style={[styles.posterWrap, { width: POSTER_WIDTH, height: POSTER_HEIGHT }]}>
+              {posterUri ? (
+                <Image source={{ uri: posterUri }} style={styles.poster} />
+              ) : (
+                <View style={[styles.poster, { backgroundColor: t.surfaceAlt }]} />
+              )}
+              {hasProgress && progress != null && (
+                <View style={styles.progressOverlay}>
+                  <View style={styles.progressTrack}>
+                    <View
+                      style={[styles.progressFill, { width: `${progress * 100}%` as any }]}
+                    />
+                  </View>
+                </View>
+              )}
+              {!hasProgress && show.totalEpisodes != null && (
+                <View style={styles.epsBadge}>
+                  <Text style={styles.epsBadgeText}>{show.totalEpisodes} eps</Text>
+                </View>
+              )}
+            </View>
+            <Text style={[styles.title, { color: t.fg }]} numberOfLines={1}>
+              {show.name}
+            </Text>
+            <View style={styles.meta}>
+              <Text style={[styles.metaText, { color: t.fgMuted }]}>
+                {show.firstAirDate?.slice(0, 4) ?? ""}
+              </Text>
+              {hasProgress && show.watchedEpisodes != null && show.totalEpisodes != null && (
+                <Text style={[styles.metaText, { color: t.fgMuted }]}>
+                  {show.watchedEpisodes}/{show.totalEpisodes}
+                </Text>
+              )}
+            </View>
+          </TouchableOpacity>
+        )
+      }}
+    />
+  )
+}
+
+const styles = StyleSheet.create({
+  grid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    paddingHorizontal: 22,
+    gap: 18,
+    paddingTop: 18,
+  },
+  listContent: {
+    paddingHorizontal: 22,
+    paddingTop: 18,
+    paddingBottom: 32,
+  },
+  row: {
+    justifyContent: "space-between",
+    marginBottom: 18,
+  },
+  cell: {
+    flexShrink: 0,
+  },
+  posterWrap: {
+    borderRadius: 10,
+    overflow: "hidden",
+    position: "relative",
+  },
+  poster: {
+    width: "100%",
+    height: "100%",
+    borderRadius: 10,
+  },
+  progressOverlay: {
+    position: "absolute",
+    left: 10,
+    right: 10,
+    bottom: 10,
+  },
+  progressTrack: {
+    height: 2.5,
+    borderRadius: 999,
+    backgroundColor: "rgba(255,255,255,0.25)",
+    overflow: "hidden",
+  },
+  progressFill: {
+    height: "100%",
+    backgroundColor: "#fff",
+    borderRadius: 999,
+  },
+  epsBadge: {
+    position: "absolute",
+    bottom: 8,
+    left: 8,
+    backgroundColor: "rgba(0,0,0,0.6)",
+    borderRadius: 6,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+  },
+  epsBadgeText: {
+    fontFamily: MONO,
+    fontSize: 10,
+    color: "#fff",
+  },
+  title: {
+    fontFamily: SANS_600,
+    fontSize: 14,
+    letterSpacing: -0.1,
+    marginTop: 10,
+    lineHeight: 18,
+  },
+  meta: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    marginTop: 2,
+  },
+  metaText: {
+    fontFamily: MONO,
+    fontSize: 11,
+  },
+  // Skeleton
+  posterSkeleton: {
+    borderRadius: 10,
+  },
+  skelLine: {
+    height: 13,
+    borderRadius: 4,
+  },
+  skelLineSmall: {
+    height: 11,
+    borderRadius: 4,
+    marginTop: 5,
+  },
+  // Empty state
+  emptyCenter: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 32,
+    paddingTop: 56,
+  },
+  ghostPosters: {
+    flexDirection: "row",
+    gap: 12,
+    marginBottom: 32,
+  },
+  ghostPoster: {
+    borderRadius: 10,
+    borderWidth: 1.5,
+    borderStyle: "dashed",
+  },
+  emptyTitle: {
+    fontFamily: SERIF_ITALIC,
+    fontSize: 32,
+    letterSpacing: -0.4,
+    lineHeight: 36,
+    textAlign: "center",
+  },
+  emptyBody: {
+    fontFamily: SANS,
+    fontSize: 13.5,
+    lineHeight: 20,
+    textAlign: "center",
+    marginTop: 10,
+    maxWidth: 280,
+  },
+  emptyBtn: {
+    marginTop: 24,
+    paddingVertical: 12,
+    paddingHorizontal: 18,
+    borderRadius: 999,
+  },
+  emptyBtnText: {
+    fontFamily: SANS_700,
+    fontSize: 13.5,
+    letterSpacing: -0.1,
+  },
+})

--- a/apps/mobile/components/PosterGrid.tsx
+++ b/apps/mobile/components/PosterGrid.tsx
@@ -7,11 +7,18 @@ import {
   StyleSheet,
   Dimensions,
   Text,
-  Animated,
 } from "react-native"
 import { useRouter } from "expo-router"
 import type { ShowWithProgress } from "@showtracker/shared"
-import { useAppTheme, STATUS_COLORS, StatusKey, SERIF_ITALIC, SANS, SANS_600, SANS_700, MONO } from "../lib/theme"
+import {
+  useAppTheme,
+  StatusKey,
+  SERIF_ITALIC,
+  SANS,
+  SANS_600,
+  SANS_700,
+  MONO,
+} from "../lib/theme"
 
 const TMDB_W342 = "https://image.tmdb.org/t/p/w342"
 const SCREEN_WIDTH = Dimensions.get("window").width
@@ -30,16 +37,40 @@ function SkeletonCard() {
   const t = useAppTheme()
   return (
     <View style={[styles.cell, { width: POSTER_WIDTH }]}>
-      <View style={[styles.posterSkeleton, { backgroundColor: t.surfaceAlt, width: POSTER_WIDTH, height: POSTER_HEIGHT }]} />
-      <View style={[styles.skelLine, { backgroundColor: t.surfaceAlt, width: "80%", marginTop: 10 }]} />
-      <View style={[styles.skelLineSmall, { backgroundColor: t.surfaceAlt, width: "50%" }]} />
+      <View
+        style={[
+          styles.posterSkeleton,
+          {
+            backgroundColor: t.surfaceAlt,
+            width: POSTER_WIDTH,
+            height: POSTER_HEIGHT,
+          },
+        ]}
+      />
+      <View
+        style={[
+          styles.skelLine,
+          { backgroundColor: t.surfaceAlt, width: "80%", marginTop: 10 },
+        ]}
+      />
+      <View
+        style={[
+          styles.skelLineSmall,
+          { backgroundColor: t.surfaceAlt, width: "50%" },
+        ]}
+      />
     </View>
   )
 }
 
-function EmptyState({ status, t }: { status: StatusKey; t: ReturnType<typeof useAppTheme> }) {
+function EmptyState({
+  status: _status,
+  t,
+}: {
+  status: StatusKey
+  t: ReturnType<typeof useAppTheme>
+}) {
   const router = useRouter()
-  const sp = STATUS_COLORS[status]
 
   return (
     <View style={styles.emptyCenter}>
@@ -49,7 +80,12 @@ function EmptyState({ status, t }: { status: StatusKey; t: ReturnType<typeof use
             key={i}
             style={[
               styles.ghostPoster,
-              { borderColor: t.borderStrong, opacity, width: POSTER_WIDTH * 0.52, height: POSTER_HEIGHT * 0.52 },
+              {
+                borderColor: t.borderStrong,
+                opacity,
+                width: POSTER_WIDTH * 0.52,
+                height: POSTER_HEIGHT * 0.52,
+              },
             ]}
           />
         ))}
@@ -63,7 +99,9 @@ function EmptyState({ status, t }: { status: StatusKey; t: ReturnType<typeof use
         onPress={() => router.push("/(tabs)/search")}
         activeOpacity={0.8}
       >
-        <Text style={[styles.emptyBtnText, { color: t.bg }]}>Browse Search →</Text>
+        <Text style={[styles.emptyBtnText, { color: t.bg }]}>
+          Browse Search →
+        </Text>
       </TouchableOpacity>
     </View>
   )
@@ -72,13 +110,13 @@ function EmptyState({ status, t }: { status: StatusKey; t: ReturnType<typeof use
 export function PosterGrid({ shows, isLoading, status, onEndReached }: Props) {
   const t = useAppTheme()
   const router = useRouter()
-  const sp = STATUS_COLORS[status]
-  const solidColor = sp.light.solid
 
   if (isLoading) {
     return (
       <View style={styles.grid}>
-        {[1, 2, 3, 4].map((i) => <SkeletonCard key={i} />)}
+        {[1, 2, 3, 4].map((i) => (
+          <SkeletonCard key={i} />
+        ))}
       </View>
     )
   }
@@ -97,9 +135,13 @@ export function PosterGrid({ shows, isLoading, status, onEndReached }: Props) {
       onEndReached={onEndReached}
       onEndReachedThreshold={0.3}
       renderItem={({ item: show }) => {
-        const posterUri = show.posterPath ? `${TMDB_W342}${show.posterPath}` : null
+        const posterUri = show.posterPath
+          ? `${TMDB_W342}${show.posterPath}`
+          : null
         const progress =
-          show.watchedEpisodes != null && show.totalEpisodes != null && show.totalEpisodes > 0
+          show.watchedEpisodes != null &&
+          show.totalEpisodes != null &&
+          show.totalEpisodes > 0
             ? show.watchedEpisodes / show.totalEpisodes
             : null
         const hasProgress = (show.watchedEpisodes ?? 0) > 0
@@ -110,24 +152,36 @@ export function PosterGrid({ shows, isLoading, status, onEndReached }: Props) {
             onPress={() => router.push(`/shows/${show.id}`)}
             activeOpacity={0.8}
           >
-            <View style={[styles.posterWrap, { width: POSTER_WIDTH, height: POSTER_HEIGHT }]}>
+            <View
+              style={[
+                styles.posterWrap,
+                { width: POSTER_WIDTH, height: POSTER_HEIGHT },
+              ]}
+            >
               {posterUri ? (
                 <Image source={{ uri: posterUri }} style={styles.poster} />
               ) : (
-                <View style={[styles.poster, { backgroundColor: t.surfaceAlt }]} />
+                <View
+                  style={[styles.poster, { backgroundColor: t.surfaceAlt }]}
+                />
               )}
               {hasProgress && progress != null && (
                 <View style={styles.progressOverlay}>
                   <View style={styles.progressTrack}>
                     <View
-                      style={[styles.progressFill, { width: `${progress * 100}%` as any }]}
+                      style={[
+                        styles.progressFill,
+                        { width: `${progress * 100}%` as any },
+                      ]}
                     />
                   </View>
                 </View>
               )}
               {!hasProgress && show.totalEpisodes != null && (
                 <View style={styles.epsBadge}>
-                  <Text style={styles.epsBadgeText}>{show.totalEpisodes} eps</Text>
+                  <Text style={styles.epsBadgeText}>
+                    {show.totalEpisodes} eps
+                  </Text>
                 </View>
               )}
             </View>
@@ -138,11 +192,13 @@ export function PosterGrid({ shows, isLoading, status, onEndReached }: Props) {
               <Text style={[styles.metaText, { color: t.fgMuted }]}>
                 {show.firstAirDate?.slice(0, 4) ?? ""}
               </Text>
-              {hasProgress && show.watchedEpisodes != null && show.totalEpisodes != null && (
-                <Text style={[styles.metaText, { color: t.fgMuted }]}>
-                  {show.watchedEpisodes}/{show.totalEpisodes}
-                </Text>
-              )}
+              {hasProgress &&
+                show.watchedEpisodes != null &&
+                show.totalEpisodes != null && (
+                  <Text style={[styles.metaText, { color: t.fgMuted }]}>
+                    {show.watchedEpisodes}/{show.totalEpisodes}
+                  </Text>
+                )}
             </View>
           </TouchableOpacity>
         )

--- a/apps/mobile/components/ShowList.tsx
+++ b/apps/mobile/components/ShowList.tsx
@@ -46,9 +46,7 @@ export function ShowList({
     <FlatList
       data={shows}
       keyExtractor={(item) => String(item.id)}
-      renderItem={({ item }) => (
-        <ShowCard show={item} compact={horizontal} />
-      )}
+      renderItem={({ item }) => <ShowCard show={item} compact={horizontal} />}
       horizontal={horizontal}
       showsHorizontalScrollIndicator={false}
       contentContainerStyle={

--- a/apps/mobile/components/StatusBadge.tsx
+++ b/apps/mobile/components/StatusBadge.tsx
@@ -1,36 +1,6 @@
 import React from "react"
-import { Chip } from "react-native-paper"
-
-const STATUS_CONFIG: Record<
-  string,
-  { label: string; backgroundColor: string; textColor: string }
-> = {
-  want_to_watch: {
-    label: "Want to Watch",
-    backgroundColor: "#e0e7ff",
-    textColor: "#3730a3",
-  },
-  watching: {
-    label: "Watching",
-    backgroundColor: "#dcfce7",
-    textColor: "#166534",
-  },
-  caught_up: {
-    label: "Caught Up",
-    backgroundColor: "#fef9c3",
-    textColor: "#713f12",
-  },
-  completed: {
-    label: "Completed",
-    backgroundColor: "#f3e8ff",
-    textColor: "#6b21a8",
-  },
-  stopped: {
-    label: "Stopped",
-    backgroundColor: "#fee2e2",
-    textColor: "#991b1b",
-  },
-}
+import { View, Text, StyleSheet, useColorScheme } from "react-native"
+import { STATUS_COLORS, STATUS_LABELS, StatusKey, SANS_700 } from "../lib/theme"
 
 type Props = {
   status: string
@@ -38,27 +8,37 @@ type Props = {
 }
 
 export function StatusBadge({ status, variant = "card" }: Props) {
-  const config = STATUS_CONFIG[status] ?? {
-    label: status,
-    backgroundColor: "#f3f4f6",
-    textColor: "#374151",
-  }
+  const scheme = useColorScheme()
+  const key = status as StatusKey
+  const sp = STATUS_COLORS[key] ?? STATUS_COLORS.want_to_watch
+  const colors = scheme === "dark" ? sp.dark : sp.light
+  const label = STATUS_LABELS[key] ?? status
 
   return (
-    <Chip
-      style={{
-        backgroundColor: config.backgroundColor,
-        alignSelf: "flex-start",
-        ...(variant === "detail" ? { paddingVertical: 9 } : {}),
-      }}
-      textStyle={{
-        color: config.textColor,
-        fontSize: variant === "detail" ? 14 : 11,
-        lineHeight: 14,
-      }}
-      compact
-    >
-      {config.label}
-    </Chip>
+    <View style={[styles.badge, { backgroundColor: colors.bg }]}>
+      <Text style={[
+        styles.label,
+        {
+          color: colors.fg,
+          fontSize: variant === "detail" ? 13 : 11,
+        },
+      ]}>
+        {label}
+      </Text>
+    </View>
   )
 }
+
+const styles = StyleSheet.create({
+  badge: {
+    alignSelf: "flex-start",
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 999,
+  },
+  label: {
+    fontFamily: SANS_700,
+    letterSpacing: 0.1,
+    lineHeight: 14,
+  },
+})

--- a/apps/mobile/components/StatusBadge.tsx
+++ b/apps/mobile/components/StatusBadge.tsx
@@ -16,13 +16,15 @@ export function StatusBadge({ status, variant = "card" }: Props) {
 
   return (
     <View style={[styles.badge, { backgroundColor: colors.bg }]}>
-      <Text style={[
-        styles.label,
-        {
-          color: colors.fg,
-          fontSize: variant === "detail" ? 13 : 11,
-        },
-      ]}>
+      <Text
+        style={[
+          styles.label,
+          {
+            color: colors.fg,
+            fontSize: variant === "detail" ? 13 : 11,
+          },
+        ]}
+      >
         {label}
       </Text>
     </View>

--- a/apps/mobile/lib/theme.ts
+++ b/apps/mobile/lib/theme.ts
@@ -38,31 +38,39 @@ export type AppTheme = typeof light
 
 export const COLORS = { light, dark }
 
-export type StatusKey = "watching" | "want_to_watch" | "caught_up" | "completed" | "stopped"
+export type StatusKey =
+  | "watching"
+  | "want_to_watch"
+  | "caught_up"
+  | "completed"
+  | "stopped"
 
 export const STATUS_COLORS: Record<
   StatusKey,
-  { light: { solid: string; bg: string; fg: string }; dark: { solid: string; bg: string; fg: string } }
+  {
+    light: { solid: string; bg: string; fg: string }
+    dark: { solid: string; bg: string; fg: string }
+  }
 > = {
   watching: {
     light: { solid: "#1a9268", bg: "#e6f7f1", fg: "#0d5c41" },
-    dark:  { solid: "#36c98a", bg: "#0d3d28", fg: "#6de0b0" },
+    dark: { solid: "#36c98a", bg: "#0d3d28", fg: "#6de0b0" },
   },
   want_to_watch: {
     light: { solid: "#8b7200", bg: "#fef9c3", fg: "#5a4a00" },
-    dark:  { solid: "#c9a030", bg: "#2e2200", fg: "#e0c060" },
+    dark: { solid: "#c9a030", bg: "#2e2200", fg: "#e0c060" },
   },
   caught_up: {
     light: { solid: "#3a5ec0", bg: "#e8eef9", fg: "#1e3a80" },
-    dark:  { solid: "#6890e0", bg: "#0e1e40", fg: "#90b0f0" },
+    dark: { solid: "#6890e0", bg: "#0e1e40", fg: "#90b0f0" },
   },
   completed: {
     light: { solid: "#8830b8", bg: "#f5e8fd", fg: "#5a1a80" },
-    dark:  { solid: "#b868e0", bg: "#280a40", fg: "#d090f0" },
+    dark: { solid: "#b868e0", bg: "#280a40", fg: "#d090f0" },
   },
   stopped: {
     light: { solid: "#c03030", bg: "#fde8e8", fg: "#801a1a" },
-    dark:  { solid: "#e06060", bg: "#400a0a", fg: "#f09090" },
+    dark: { solid: "#e06060", bg: "#400a0a", fg: "#f09090" },
   },
 }
 

--- a/apps/mobile/lib/theme.ts
+++ b/apps/mobile/lib/theme.ts
@@ -1,0 +1,80 @@
+import { useColorScheme } from "react-native"
+
+export const SERIF = "InstrumentSerif_400Regular"
+export const SERIF_ITALIC = "InstrumentSerif_400Regular_Italic"
+export const SANS = "DMSans_400Regular"
+export const SANS_500 = "DMSans_500Medium"
+export const SANS_600 = "DMSans_600SemiBold"
+export const SANS_700 = "DMSans_700Bold"
+export const MONO = "JetBrainsMono_400Regular"
+export const MONO_500 = "JetBrainsMono_500Medium"
+export const MONO_600 = "JetBrainsMono_600SemiBold"
+
+const light = {
+  bg: "#FAFAF7",
+  surface: "#FFFFFF",
+  surfaceAlt: "#F2F1EC",
+  border: "#E6E4DD",
+  borderStrong: "#D7D4CB",
+  fg: "#16161A",
+  fgMuted: "#5C5B57",
+  fgFaint: "#8E8C85",
+  accent: "#1a9268",
+}
+
+const dark = {
+  bg: "#0E0F12",
+  surface: "#16181C",
+  surfaceAlt: "#1C1F24",
+  border: "#262A30",
+  borderStrong: "#3A3F47",
+  fg: "#F4F4F0",
+  fgMuted: "#9C9C95",
+  fgFaint: "#6F6E68",
+  accent: "#36c98a",
+}
+
+export type AppTheme = typeof light
+
+export const COLORS = { light, dark }
+
+export type StatusKey = "watching" | "want_to_watch" | "caught_up" | "completed" | "stopped"
+
+export const STATUS_COLORS: Record<
+  StatusKey,
+  { light: { solid: string; bg: string; fg: string }; dark: { solid: string; bg: string; fg: string } }
+> = {
+  watching: {
+    light: { solid: "#1a9268", bg: "#e6f7f1", fg: "#0d5c41" },
+    dark:  { solid: "#36c98a", bg: "#0d3d28", fg: "#6de0b0" },
+  },
+  want_to_watch: {
+    light: { solid: "#8b7200", bg: "#fef9c3", fg: "#5a4a00" },
+    dark:  { solid: "#c9a030", bg: "#2e2200", fg: "#e0c060" },
+  },
+  caught_up: {
+    light: { solid: "#3a5ec0", bg: "#e8eef9", fg: "#1e3a80" },
+    dark:  { solid: "#6890e0", bg: "#0e1e40", fg: "#90b0f0" },
+  },
+  completed: {
+    light: { solid: "#8830b8", bg: "#f5e8fd", fg: "#5a1a80" },
+    dark:  { solid: "#b868e0", bg: "#280a40", fg: "#d090f0" },
+  },
+  stopped: {
+    light: { solid: "#c03030", bg: "#fde8e8", fg: "#801a1a" },
+    dark:  { solid: "#e06060", bg: "#400a0a", fg: "#f09090" },
+  },
+}
+
+export const STATUS_LABELS: Record<StatusKey, string> = {
+  watching: "Watching",
+  want_to_watch: "Want",
+  caught_up: "Caught Up",
+  completed: "Completed",
+  stopped: "Stopped",
+}
+
+export function useAppTheme(): AppTheme {
+  const scheme = useColorScheme()
+  return scheme === "dark" ? dark : light
+}

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -1,12 +1,12 @@
-const { getDefaultConfig } = require("expo/metro-config");
-const path = require("path");
+const { getDefaultConfig } = require("expo/metro-config")
+const path = require("path")
 
-const projectRoot = __dirname;
-const monorepoRoot = path.resolve(projectRoot, "../..");
+const projectRoot = __dirname
+const monorepoRoot = path.resolve(projectRoot, "../..")
 
-const config = getDefaultConfig(projectRoot);
+const config = getDefaultConfig(projectRoot)
 
-config.watchFolders = [monorepoRoot];
+config.watchFolders = [monorepoRoot]
 
 // Force react and react-native to always resolve from the mobile app's
 // node_modules. extraNodeModules is a fallback and loses to the natural
@@ -23,9 +23,9 @@ config.resolver.resolveRequest = (context, moduleName, platform) => {
     return {
       filePath: require.resolve(moduleName, { paths: [projectRoot] }),
       type: "sourceFile",
-    };
+    }
   }
-  return context.resolveRequest(context, moduleName, platform);
-};
+  return context.resolveRequest(context, moduleName, platform)
+}
 
-module.exports = config;
+module.exports = config

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -10,6 +10,9 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
+    "@expo-google-fonts/dm-sans": "^0.4.2",
+    "@expo-google-fonts/instrument-serif": "^0.4.1",
+    "@expo-google-fonts/jetbrains-mono": "^0.4.1",
     "@expo/vector-icons": "^15.1.1",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-community/masked-view": "^0.1.11",
@@ -18,10 +21,12 @@
     "@tanstack/react-query-persist-client": "^5.100.10",
     "expo": "~54.0.33",
     "expo-constants": "~18.0.13",
+    "expo-linear-gradient": "~15.0.8",
     "expo-linking": "~8.0.12",
     "expo-notifications": "~0.32.17",
     "expo-router": "~6.0.23",
     "expo-secure-store": "~15.0.8",
+    "expo-splash-screen": "~31.0.13",
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",
     "react-native": "0.81.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -129,6 +129,9 @@
       "name": "@showtracker/mobile",
       "version": "1.0.0",
       "dependencies": {
+        "@expo-google-fonts/dm-sans": "^0.4.2",
+        "@expo-google-fonts/instrument-serif": "^0.4.1",
+        "@expo-google-fonts/jetbrains-mono": "^0.4.1",
         "@expo/vector-icons": "^15.1.1",
         "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-native-community/masked-view": "^0.1.11",
@@ -137,10 +140,12 @@
         "@tanstack/react-query-persist-client": "^5.100.10",
         "expo": "~54.0.33",
         "expo-constants": "~18.0.13",
+        "expo-linear-gradient": "~15.0.8",
         "expo-linking": "~8.0.12",
         "expo-notifications": "~0.32.17",
         "expo-router": "~6.0.23",
         "expo-secure-store": "~15.0.8",
+        "expo-splash-screen": "~31.0.13",
         "expo-status-bar": "~3.0.9",
         "react": "19.1.0",
         "react-native": "0.81.5",
@@ -173,6 +178,27 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "apps/mobile/node_modules/@expo/prebuild-config": {
+      "version": "54.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-54.0.8.tgz",
+      "integrity": "sha512-EA7N4dloty2t5Rde+HP0IEE+nkAQiu4A/+QGZGT9mFnZ5KKjPPkqSyYcRvP5bhQE10D+tvz6X0ngZpulbMdbsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~12.0.13",
+        "@expo/config-plugins": "~54.0.4",
+        "@expo/config-types": "^54.0.10",
+        "@expo/image-utils": "^0.8.8",
+        "@expo/json-file": "^10.0.8",
+        "@react-native/normalize-colors": "0.81.5",
+        "debug": "^4.3.1",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.6.0",
+        "xml2js": "0.6.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "apps/mobile/node_modules/@expo/vector-icons": {
@@ -462,6 +488,17 @@
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "apps/mobile/node_modules/expo-linear-gradient": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-15.0.8.tgz",
+      "integrity": "sha512-V2d8Wjn0VzhPHO+rrSBtcl+Fo+jUUccdlmQ6OoL9/XQB7Qk3d9lYrqKDJyccwDxmQT10JdST3Tmf2K52NLc3kw==",
+      "license": "MIT",
       "peerDependencies": {
         "expo": "*",
         "react": "*",
@@ -782,6 +819,18 @@
         "expo": "*"
       }
     },
+    "apps/mobile/node_modules/expo-splash-screen": {
+      "version": "31.0.13",
+      "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-31.0.13.tgz",
+      "integrity": "sha512-1epJLC1cDlwwj089R2h8cxaU5uk4ONVAC+vzGiTZH4YARQhL4Stlz1MbR6yAS173GMosvkE6CAeihR7oIbCkDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/prebuild-config": "^54.0.8"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "apps/mobile/node_modules/expo-status-bar": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/expo-status-bar/-/expo-status-bar-3.0.9.tgz",
@@ -880,27 +929,6 @@
         "react-native": {
           "optional": true
         }
-      }
-    },
-    "apps/mobile/node_modules/expo/node_modules/@expo/cli/node_modules/@expo/prebuild-config": {
-      "version": "54.0.8",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-54.0.8.tgz",
-      "integrity": "sha512-EA7N4dloty2t5Rde+HP0IEE+nkAQiu4A/+QGZGT9mFnZ5KKjPPkqSyYcRvP5bhQE10D+tvz6X0ngZpulbMdbsg==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config": "~12.0.13",
-        "@expo/config-plugins": "~54.0.4",
-        "@expo/config-types": "^54.0.10",
-        "@expo/image-utils": "^0.8.8",
-        "@expo/json-file": "^10.0.8",
-        "@react-native/normalize-colors": "0.81.5",
-        "debug": "^4.3.1",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.6.0",
-        "xml2js": "0.6.0"
-      },
-      "peerDependencies": {
-        "expo": "*"
       }
     },
     "apps/mobile/node_modules/expo/node_modules/@expo/metro-config": {
@@ -3763,6 +3791,24 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@expo-google-fonts/dm-sans": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/dm-sans/-/dm-sans-0.4.2.tgz",
+      "integrity": "sha512-e/fLH5aCJzkEenz7axvEn8N7IJAKhUwNjIxS75h9j+Ip1M9S7d22M19gJN3A7QW4egVkBJRyQh1hQFhngQn9yA==",
+      "license": "MIT AND OFL-1.1"
+    },
+    "node_modules/@expo-google-fonts/instrument-serif": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/instrument-serif/-/instrument-serif-0.4.1.tgz",
+      "integrity": "sha512-1CgCrLbTSgE7RV8ZrTT7i06UAyNQDBrhxQuxkReNnfq5yvUhTmvpOK17grlEsXG5p04lJ1ZXGiIjPeHo6X0sXg==",
+      "license": "MIT AND OFL-1.1"
+    },
+    "node_modules/@expo-google-fonts/jetbrains-mono": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/jetbrains-mono/-/jetbrains-mono-0.4.1.tgz",
+      "integrity": "sha512-CslACrtMOcRwoWXCO7OMEI+9w3fukWSoBtvNz46OqPoogEuuoY0tkDY1O8sFumk8t0pC6Cx0Xr95O0TOQhpkug==",
+      "license": "MIT AND OFL-1.1"
     },
     "node_modules/@expo/code-signing-certificates": {
       "version": "0.0.6",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,13 @@ export default defineConfig({
     alias: {
       "@": path.resolve(import.meta.dirname, "apps", "web", "src"),
       "@shared": path.resolve(import.meta.dirname, "packages", "shared"),
-      "@showtracker/api-client": path.resolve(import.meta.dirname, "packages", "api-client", "src", "index.ts"),
+      "@showtracker/api-client": path.resolve(
+        import.meta.dirname,
+        "packages",
+        "api-client",
+        "src",
+        "index.ts"
+      ),
     },
   },
   root: path.resolve(import.meta.dirname, "apps", "web"),


### PR DESCRIPTION
## Summary

- Implements the **Cinematic** direction selected during a Claude Design review session — poster-forward, editorial serif typography, and a per-status color system (Watching green · Want amber · Caught Up blue · Completed violet)
- Full-bleed hero on the Dashboard features the next unwatched episode of the most recently-added Watching show, replacing the old stats grid
- Library switches from a row list to a 2-column poster grid with underline tabs and live counts
- Search gets a serif header, custom input, and poster-forward result rows with a corner collection badge
- Show Detail gets a cinematic backdrop, glass navigation buttons, progress strip, and circle-toggle episode list
- New `lib/theme.ts` centralises all design tokens; new `PosterGrid` component replaces `ShowList` in all four library screens

## New dependencies

- `@expo-google-fonts/instrument-serif`, `dm-sans`, `jetbrains-mono`
- `expo-linear-gradient`, `expo-splash-screen`

## Test plan

- [ ] Run `expo start` in `apps/mobile/` and open on iOS simulator
- [ ] Dashboard: hero shows backdrop image, stats row, 3 horizontal carousels; "Mark watched" marks the episode
- [ ] Library: serif "Library" header, underline tabs with correct counts, 2-col poster grid per tab
- [ ] Empty state: ghost poster trio + italic "Nothing here yet" + Search CTA
- [ ] Search: serif header, custom input, poster rows with collection badge for in-collection shows
- [ ] Show Detail: cinematic backdrop + gradient, glass back button, progress strip, season pills, episode toggle circles
- [ ] Toggle device to dark mode — all screens switch to dark Cinematic palette
- [ ] TypeScript: `npm run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)