### PR TITLE
fix: improve show grid skeleton, medium viewport columns, and sidebar counts

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -61,14 +61,16 @@ export function AppSidebar() {
     totalShows: number
     watchingShows: number
     completedShows: number
+    wantToWatchShows: number
+    caughtUpShows: number
     episodesWatched: number
   }>({ queryKey: ["/api/stats"] })
 
   const libraryCounts: Record<StatusKey, number | undefined> = {
     watching: stats?.watchingShows,
     completed: stats?.completedShows,
-    want_to_watch: undefined,
-    caught_up: undefined,
+    want_to_watch: stats?.wantToWatchShows,
+    caught_up: stats?.caughtUpShows,
     stopped: undefined,
   }
 

--- a/apps/web/src/components/show-grid.tsx
+++ b/apps/web/src/components/show-grid.tsx
@@ -13,12 +13,12 @@ interface ShowGridProps {
 export const gridColumns = {
   base: 2,
   sm: 3,
-  md: 4,
+  md: 3,
   lg: 5,
   xl: 6,
   "2xl": 6,
 }
-export const showGridClass = `grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-x-6 gap-y-8`
+export const showGridClass = `grid grid-cols-2 sm:grid-cols-3 md:grid-cols-3 lg:grid-cols-5 xl:grid-cols-6 gap-x-6 gap-y-8`
 
 export function ShowGrid({
   shows,
@@ -33,14 +33,13 @@ export function ShowGrid({
   )
 
   if (isLoading) {
+    const skeletonCount = gridColumns[breakpoint] * 3
     if (noContainer) {
-      return (
-        <>{[...Array(gridColumns[breakpoint])].map((_, i) => skeleton(i))}</>
-      )
+      return <>{[...Array(skeletonCount)].map((_, i) => skeleton(i))}</>
     }
     return (
       <div className={showGridClass}>
-        {[...Array(gridColumns[breakpoint])].map((_, i) => skeleton(i))}
+        {[...Array(skeletonCount)].map((_, i) => skeleton(i))}
       </div>
     )
   }

--- a/apps/web/src/pages/library-view.tsx
+++ b/apps/web/src/pages/library-view.tsx
@@ -1,5 +1,5 @@
 import { ShowWithProgress } from "@shared/schema"
-import { ShowGrid } from "@/components/show-grid"
+import { ShowGrid, showGridClass } from "@/components/show-grid"
 import { Skeleton } from "@/components/ui/skeleton"
 import { statusPalette, type StatusKey } from "@/lib/status"
 import { useTheme } from "@/components/theme-provider"
@@ -148,7 +148,7 @@ export function LibraryView({
       {hasNextPage && (
         <div ref={observerTarget} className="py-8">
           {isFetchingNextPage && (
-            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-x-6 gap-y-8 mt-4">
+            <div className={`${showGridClass} mt-4`}>
               {[...Array(6)].map((_, i) => (
                 <Skeleton key={i} className="w-full aspect-[2/3] rounded-lg" />
               ))}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -287,6 +287,14 @@ export async function registerRoutes(app: Express): Promise<Server> {
             activeShows.filter(
               (s: { status: string }) => s.status === "completed"
             ).length || 0,
+          wantToWatchShows:
+            activeShows.filter(
+              (s: { status: string }) => s.status === "want_to_watch"
+            ).length || 0,
+          caughtUpShows:
+            activeShows.filter(
+              (s: { status: string }) => s.status === "caught_up"
+            ).length || 0,
           episodesWatched,
         }
 


### PR DESCRIPTION
## Summary

- Show 3 rows of skeletons instead of 1 during loading for a more realistic placeholder
- Reduce show grid from 4 → 3 columns at the `md` breakpoint to avoid cramped layouts when the sidebar is open
- Add `want_to_watch` and `caught_up` counts to the `/api/stats` response and display them in the sidebar alongside the existing Watching and Completed counts

## Test plan

- [ ] Trigger a loading state on any library page and confirm 3 rows of skeletons appear
- [ ] Resize browser to ~800px wide and confirm the grid looks comfortable (3 columns)
- [ ] Check the sidebar shows counts next to all four library categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)