### PR TITLE
fix: skip Vercel production deploys from GitHub integration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,7 @@
 {
   "version": 2,
   "buildCommand": "npm run build",
+  "ignoreCommand": "[ \"$VERCEL_ENV\" = \"production\" ] && exit 0 || exit 1",
   "outputDirectory": "dist/public",
   "functions": {
     "api/index.ts": {


### PR DESCRIPTION
## Summary

Adds `ignoreCommand` to `vercel.json` to prevent Vercel's GitHub integration from ever auto-promoting to production.

- GitHub push to `main` → `$VERCEL_ENV` is `"production"` → exits 0 → build skipped
- PR branches → `$VERCEL_ENV` is `"preview"` → exits 1 → preview deploy proceeds as normal
- Release workflow `vercel deploy --prod` → CLI deploy, `ignoreCommand` is never evaluated → production deploy works

Production deploys now only happen via the `release-web.yml` workflow when a `web/v*` release is created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)