### PR TITLE
fix(ci): action versions, APK upload permissions, Vercel TS errors

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,8 +13,8 @@ jobs:
     name: TypeScript (root)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -25,8 +25,8 @@ jobs:
     name: TypeScript (mobile)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -39,8 +39,8 @@ jobs:
     name: Build web
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -51,8 +51,8 @@ jobs:
     name: Build mobile JS bundle
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -47,21 +47,23 @@ jobs:
       startsWith(github.ref, 'refs/tags/mobile/v') ||
       startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -105,16 +107,12 @@ jobs:
       - name: Find APK
         id: apk
         run: |
-          path=$(find apps/mobile/android/app/build/outputs/apk/release -name "*.apk" | head -1)
-          echo "path=$path" >> $GITHUB_OUTPUT
-          echo "name=ShowTracker-${{ github.ref_name }}.apk" >> $GITHUB_OUTPUT
+          src=$(find apps/mobile/android/app/build/outputs/apk/release -name "*.apk" | head -1)
+          dest="$(dirname "$src")/ShowTracker-${{ github.ref_name }}.apk"
+          mv "$src" "$dest"
+          echo "path=$dest" >> $GITHUB_OUTPUT
 
       - name: Upload APK to release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v3
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ${{ steps.apk.outputs.path }}
-          asset_name: ${{ steps.apk.outputs.name }}
-          asset_content_type: application/vnd.android.package-archive
+          files: ${{ steps.apk.outputs.path }}

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "CommonJS",
-    "moduleResolution": "node",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,


### PR DESCRIPTION
## Summary

- **Node.js 24 action versions** — bumps `actions/checkout`, `setup-node`, `setup-java`, and `cache` to their latest major versions (v6/v6/v5/v5) which natively target Node.js 24, ahead of the June 16 forced cutover
- **APK upload permissions** — adds `permissions: contents: write` to `build-apk`; the repo default is read-only, causing the `Resource not accessible by integration` error on every release
- **APK upload action** — replaces the unmaintained `actions/upload-release-asset@v1` with `softprops/action-gh-release@v3`; the APK is renamed to `ShowTracker-<tag>.apk` in the Find APK step so the asset name is preserved
- **Vercel TS annotation errors** — fixes `api/tsconfig.json` (`module: CommonJS` → `ESNext`, `moduleResolution: node` → `bundler`); root cause: `api/index.ts` dynamically imports `../dev/vite.ts` which uses `import.meta`, and Vercel was type-checking that chain under CommonJS settings

## Test plan

- [ ] Trigger a `v*` release and confirm the APK is attached to the release with the correct filename
- [ ] Confirm no `Resource not accessible by integration` error in the upload step
- [ ] Confirm no Node.js 20 deprecation warnings in either job
- [ ] Confirm no `import.meta` / `@tailwindcss/vite` TypeScript annotation errors in the Vercel build step

🤖 Generated with [Claude Code](https://claude.com/claude-code)