### PR TITLE
fix: align loading skeletons with partial grid rows

### DIFF
--- a/apps/web/src/components/show-grid.tsx
+++ b/apps/web/src/components/show-grid.tsx
@@ -6,6 +6,7 @@ import { useBreakpoint } from "@/hooks/use-breakpoint"
 interface ShowGridProps {
   shows?: ShowWithProgress[]
   isLoading: boolean
+  isFetchingNextPage?: boolean
   emptyMessage?: React.ReactNode
   noContainer?: boolean
 }
@@ -23,6 +24,7 @@ export const showGridClass = `grid grid-cols-2 sm:grid-cols-3 md:grid-cols-3 lg:
 export function ShowGrid({
   shows,
   isLoading,
+  isFetchingNextPage,
   emptyMessage,
   noContainer,
 }: ShowGridProps) {
@@ -45,12 +47,20 @@ export function ShowGrid({
   }
 
   if (shows && shows.length > 0) {
+    const columns = gridColumns[breakpoint]
+    const remainder = shows.length % columns
+    const fillCount =
+      isFetchingNextPage && remainder > 0 ? columns - remainder : 0
+    const tailSkeletonCount = isFetchingNextPage ? fillCount + columns : 0
+
     if (noContainer) {
       return (
         <>
           {shows.map((show) => (
             <ShowCard key={show.id} show={show} href={`/show/${show.id}`} />
           ))}
+          {isFetchingNextPage &&
+            [...Array(tailSkeletonCount)].map((_, i) => skeleton(i))}
         </>
       )
     }
@@ -59,6 +69,8 @@ export function ShowGrid({
         {shows.map((show) => (
           <ShowCard key={show.id} show={show} href={`/show/${show.id}`} />
         ))}
+        {isFetchingNextPage &&
+          [...Array(tailSkeletonCount)].map((_, i) => skeleton(i))}
       </div>
     )
   }

--- a/apps/web/src/pages/library-view.tsx
+++ b/apps/web/src/pages/library-view.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react"
 import { ShowWithProgress } from "@shared/schema"
-import { ShowGrid, showGridClass } from "@/components/show-grid"
+import { ShowGrid } from "@/components/show-grid"
 import { Skeleton } from "@/components/ui/skeleton"
 import { statusPalette, type StatusKey } from "@/lib/status"
 import { useTheme } from "@/components/theme-provider"
@@ -239,6 +239,7 @@ export function LibraryView({
         <ShowGrid
           shows={shows}
           isLoading={isLoading}
+          isFetchingNextPage={isFetchingNextPage}
           emptyMessage={emptyMessage}
         />
       ) : (
@@ -249,17 +250,7 @@ export function LibraryView({
         />
       )}
 
-      {hasNextPage && (
-        <div ref={observerTarget} className="py-8">
-          {isFetchingNextPage && (
-            <div className={`${showGridClass} mt-4`}>
-              {[...Array(6)].map((_, i) => (
-                <Skeleton key={i} className="w-full aspect-[2/3] rounded-lg" />
-              ))}
-            </div>
-          )}
-        </div>
-      )}
+      {hasNextPage && <div ref={observerTarget} className="py-4" />}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Skeletons injected into the **same grid container** as loaded shows, so they naturally complete the trailing partial row instead of floating in a separate block below
- Added `isFetchingNextPage` prop to `ShowGrid` — when set, computes fill count (`columns - remainder`) and appends fill + one full row of skeletons at the tail of the grid
- Removed the separate skeleton div in `library-view.tsx`; the observer target is now a slim standalone div

## Test plan

- [ ] Open the library with enough shows to paginate (e.g. 10 shows, 6-col grid at xl breakpoint)
- [ ] Scroll to trigger next-page fetch — confirm skeletons complete the partial last row and add a full row below, with no gap between loaded cards and skeletons
- [ ] Verify initial-load skeleton count is unchanged (3 full rows)
- [ ] Check at different breakpoints (2-col mobile, 3-col tablet, 5-col lg, 6-col xl)

🤖 Generated with [Claude Code](https://claude.com/claude-code)