### PR TITLE
fix(api): switch api to ESM to fix Vercel Lambda and TS annotation errors

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,3 +1,3 @@
 {
-  "type": "commonjs"
+  "type": "module"
 }


### PR DESCRIPTION
## Problem

`api/package.json` explicitly declared `"type": "commonjs"`, which Vercel deploys to `/var/task/api/package.json` in the Lambda runtime. PR #15 changed `api/tsconfig.json` to `module: ESNext`, which made the bundler emit `import`/`export` syntax — but the Lambda's nearest `package.json` said `commonjs`, so Node.js refused to load it:

```
Failed to load the ES module: /var/task/api/index.js.
Make sure to set "type": "module" in the nearest package.json file or use the .mjs extension.
```

## Fix

Align both files on ESM:
- `api/package.json`: `"type": "commonjs"` → `"type": "module"` so the Lambda runtime correctly identifies the ESM output
- `api/tsconfig.json` stays `module: ESNext` / `moduleResolution: bundler` (already set by PR #15)

This is consistent with the project-wide `"type": "module"` in the root `package.json`. It also permanently fixes the Vercel TypeScript annotation errors (TS1343/TS2307) about `import.meta` and `@tailwindcss/vite`, since those files are now checked under ESNext settings.

## Test plan

- [ ] Verify production Lambda no longer crashes on startup
- [ ] Confirm no `import.meta` / `@tailwindcss/vite` TypeScript annotation errors in the Vercel build log
- [ ] Confirm local dev server still works with `npm run dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)