### PR TITLE
fix(api): revert api to CommonJS to fix Vercel Lambda

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,3 +1,3 @@
 {
-  "type": "module"
+  "type": "commonjs"
 }

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
+    "module": "CommonJS",
+    "moduleResolution": "node",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,

--- a/apps/mobile/app/(tabs)/search.tsx
+++ b/apps/mobile/app/(tabs)/search.tsx
@@ -35,7 +35,6 @@ import {
 
 const TMDB_W200 = "https://image.tmdb.org/t/p/w200"
 
-
 function CollectionBadge({ status }: { status: StatusKey }) {
   const sp = STATUS_COLORS[status]
   return (

--- a/apps/mobile/components/PosterGrid.tsx
+++ b/apps/mobile/components/PosterGrid.tsx
@@ -109,7 +109,13 @@ function EmptyState({
   )
 }
 
-export function PosterGrid({ shows, isLoading, status, onEndReached, isFetchingNextPage }: Props) {
+export function PosterGrid({
+  shows,
+  isLoading,
+  status,
+  onEndReached,
+  isFetchingNextPage,
+}: Props) {
   const t = useAppTheme()
   const router = useRouter()
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,7 +17,7 @@ const compat = new FlatCompat({
 export default [
   // Global ignores
   {
-    ignores: ["node_modules/**", "dist/**"],
+    ignores: ["node_modules/**", "dist/**", ".vercel/**"],
   },
 
   // Base ESLint recommended config

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1066,8 +1066,8 @@ async function batchShowProgress(
 ) {
   const showIds = userShows.map((us) => us.show_id)
 
-  const [{ data: watchProgressRows }, { data: episodeRows }] = await Promise.all(
-    [
+  const [{ data: watchProgressRows }, { data: episodeRows }] =
+    await Promise.all([
       supabase
         .from("watch_progress")
         .select("show_id, season_number, episode_number")
@@ -1081,8 +1081,7 @@ async function batchShowProgress(
         .order("show_id", { ascending: true })
         .order("season_number", { ascending: true })
         .order("episode_number", { ascending: true }),
-    ]
-  )
+    ])
 
   // Group watch progress by show_id
   const watchedByShow: Record<number, Set<string>> = {}
@@ -1104,7 +1103,13 @@ async function batchShowProgress(
   for (const ep of episodeRows ?? []) {
     const sid = ep.show_id as number
     if (!episodesByShow[sid]) episodesByShow[sid] = []
-    episodesByShow[sid].push(ep as { season_number: number; episode_number: number; air_date: string | null })
+    episodesByShow[sid].push(
+      ep as {
+        season_number: number
+        episode_number: number
+        air_date: string | null
+      }
+    )
   }
 
   return userShows.map((us) => {
@@ -1128,9 +1133,7 @@ async function batchShowProgress(
         if (!watched.has(key)) {
           const airDate = ep.air_date ?? null
           const daysUntil = airDate
-            ? Math.ceil(
-                (new Date(airDate).getTime() - Date.now()) / 86400000
-              )
+            ? Math.ceil((new Date(airDate).getTime() - Date.now()) / 86400000)
             : null
           nextEpisode = {
             season: ep.season_number,


### PR DESCRIPTION
## Problem

Switching `api/package.json` to `"type": "module"` hit a deeper ESM incompatibility. Vercel copies `server/**` alongside the Lambda as **separate files** (via `includeFiles` in `vercel.json`) rather than bundling them into `api/index.js`. Node.js ESM requires explicit `.js` extensions on all relative imports:

```
// ESM requires this:
import '../server/env-config.js'

// But the codebase uses this everywhere:
import '../server/env-config'
```

This causes the runtime crash:
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/var/task/server/env-config'
```

Fixing this properly would require adding `.js` extensions to every relative import across `api/` and `server/` — a significant refactor the codebase wasn't designed for.

## Fix

Revert both files to their original CJS state:
- `api/tsconfig.json`: `module: CommonJS`, `moduleResolution: node`
- `api/package.json`: `"type": "commonjs"`

## On the Vercel TypeScript annotation errors

The `import.meta` / `@tailwindcss/vite` errors that appear as Vercel build annotations are cosmetic — they do not fail the deploy. The `dev/vite.ts` code that uses `import.meta` is guarded by `if (!isVercel)` and never executes in the Lambda environment.

## Test plan

- [ ] Verify Lambda starts without module resolution errors
- [ ] Verify Vercel deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)