### PR TITLE
Fix watching count, season loading bug, and add profile page

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,16 @@ npx tsc --noEmit        # TypeScript check
 
 EAS builds are configured in [`apps/mobile/eas.json`](./apps/mobile/eas.json). Run `eas build` to produce a production build via Expo Application Services.
 
+#### Native dev client vs. Metro-only, especially when using git worktrees
+
+This app uses native modules (`react-native-auth0`, `expo-notifications`), so it needs a compiled **dev client** on the simulator/device — Expo Go alone won't work (`TurboModuleRegistry.getEnforcing(...): 'A0Auth0' could not be found` means you're on Expo Go or a stale dev client).
+
+`ios/` and `android/` are gitignored and regenerated on demand by `expo prebuild` (which `expo run:ios`/`run:android` call automatically). That means:
+
+- **Only rebuild the native shell (`npx expo run:ios` / `run:android`) when native dependencies or `app.json` config/plugins actually change.** A full rebuild takes several minutes and, per checkout, regenerates multi-GB `ios/`/`android/`/Pods/DerivedData directories.
+- **For everyday JS/TS-only changes, don't rebuild** — run `npx expo start --dev-client` and the already-installed dev client on the simulator will reconnect and load the new bundle in seconds.
+- **In a git worktree specifically**: `ios/`/`android/` won't exist there (gitignored, so a fresh worktree has none), so rebuilding native from inside a worktree means a full prebuild + Xcode/Gradle build every time, and a separate multi-GB native project per worktree. Prefer building the dev client once from a single canonical checkout (e.g. your main clone), installing it on the simulator, and then just pointing `expo start --dev-client` at it from whichever worktree you're actively editing — the dev client doesn't care which directory served its JS bundle.
+
 ## Documentation in this repo
 
 - [DATABASE_SETUP.md](./DATABASE_SETUP.md) — apply `database-schema.sql` in Supabase

--- a/apps/mobile/app/(tabs)/library/_layout.tsx
+++ b/apps/mobile/app/(tabs)/library/_layout.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { View, ScrollView, TouchableOpacity, StyleSheet } from "react-native"
 import { Text } from "react-native-paper"
 import { Slot, useRouter, usePathname } from "expo-router"
+import { Ionicons } from "@expo/vector-icons"
 import { useQuery } from "@tanstack/react-query"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 import {
@@ -95,10 +96,25 @@ export default function LibraryLayout() {
     <View style={[styles.container, { backgroundColor: t.bg }]}>
       {/* Header */}
       <View style={[styles.header, { paddingTop: insets.top + 14 }]}>
-        <Text style={[styles.eyebrow, { color: t.fgFaint }]}>
-          {activeCount != null ? `${activeCount} SHOWS` : ""}
-        </Text>
-        <Text style={[styles.title, { color: t.fg }]}>Library</Text>
+        <View style={styles.headerRow}>
+          <View>
+            <Text style={[styles.eyebrow, { color: t.fgFaint }]}>
+              {activeCount != null ? `${activeCount} SHOWS` : ""}
+            </Text>
+            <Text style={[styles.title, { color: t.fg }]}>Library</Text>
+          </View>
+          <TouchableOpacity
+            onPress={() => router.push("/profile")}
+            style={styles.profileBtn}
+            activeOpacity={0.7}
+          >
+            <Ionicons
+              name="person-circle-outline"
+              size={28}
+              color={t.fgMuted}
+            />
+          </TouchableOpacity>
+        </View>
       </View>
 
       {/* Underline tabs */}
@@ -165,6 +181,14 @@ const styles = StyleSheet.create({
   header: {
     paddingHorizontal: 22,
     paddingBottom: 16,
+  },
+  headerRow: {
+    flexDirection: "row",
+    alignItems: "flex-end",
+    justifyContent: "space-between",
+  },
+  profileBtn: {
+    marginBottom: 6,
   },
   eyebrow: {
     fontFamily: SANS,

--- a/apps/mobile/app/profile.tsx
+++ b/apps/mobile/app/profile.tsx
@@ -1,0 +1,302 @@
+import React, { useState } from "react"
+import {
+  View,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  Alert,
+  Image,
+} from "react-native"
+import { Text, ActivityIndicator } from "react-native-paper"
+import { useRouter } from "expo-router"
+import { useMutation } from "@tanstack/react-query"
+import { useSafeAreaInsets } from "react-native-safe-area-context"
+import { apiRequest } from "@showtracker/api-client"
+import { useAuth } from "../lib/auth"
+import {
+  useAppTheme,
+  STATUS_COLORS,
+  SERIF,
+  SANS,
+  SANS_600,
+  SANS_700,
+} from "../lib/theme"
+
+export default function ProfileScreen() {
+  const router = useRouter()
+  const t = useAppTheme()
+  const insets = useSafeAreaInsets()
+  const { user, logout, refreshUser } = useAuth()
+  const destructive = STATUS_COLORS.stopped.light.solid
+
+  const [name, setName] = useState(user?.name ?? "")
+  const [picture, setPicture] = useState(user?.picture ?? "")
+
+  const updateProfile = useMutation({
+    mutationFn: () =>
+      apiRequest("PATCH", "/api/user/profile", { name, picture }),
+    onSuccess: () => refreshUser(),
+    onError: () =>
+      Alert.alert("Error", "Failed to update profile. Please try again."),
+  })
+
+  const deleteAccount = useMutation({
+    mutationFn: () => apiRequest("DELETE", "/api/user"),
+    onSuccess: () => logout(),
+    onError: () =>
+      Alert.alert("Error", "Failed to delete account. Please try again."),
+  })
+
+  const confirmDelete = () => {
+    Alert.alert(
+      "Delete your account?",
+      "This will permanently delete your account, library, and watch history. This action cannot be undone.",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Delete Account",
+          style: "destructive",
+          onPress: () => deleteAccount.mutate(),
+        },
+      ]
+    )
+  }
+
+  return (
+    <View style={[styles.container, { backgroundColor: t.bg }]}>
+      <View style={[styles.header, { paddingTop: insets.top + 12 }]}>
+        <TouchableOpacity
+          onPress={() => router.back()}
+          style={styles.backBtn}
+          activeOpacity={0.8}
+        >
+          <Text style={[styles.backBtnText, { color: t.fg }]}>‹</Text>
+        </TouchableOpacity>
+        <Text style={[styles.title, { color: t.fg }]}>Profile</Text>
+      </View>
+
+      <View style={styles.content}>
+        <View style={styles.avatarRow}>
+          {picture ? (
+            <Image source={{ uri: picture }} style={styles.avatar} />
+          ) : (
+            <View
+              style={[
+                styles.avatar,
+                styles.avatarFallback,
+                { backgroundColor: t.surfaceAlt },
+              ]}
+            >
+              <Text style={[styles.avatarFallbackText, { color: t.fgMuted }]}>
+                {name?.charAt(0).toUpperCase() || "?"}
+              </Text>
+            </View>
+          )}
+          <Text style={[styles.email, { color: t.fgMuted }]}>
+            {user?.email}
+          </Text>
+        </View>
+
+        <Text style={[styles.label, { color: t.fgMuted }]}>Name</Text>
+        <TextInput
+          style={[
+            styles.input,
+            { color: t.fg, borderColor: t.border, backgroundColor: t.surface },
+          ]}
+          value={name}
+          onChangeText={setName}
+          placeholder="Your name"
+          placeholderTextColor={t.fgFaint}
+        />
+
+        <Text style={[styles.label, { color: t.fgMuted }]}>Avatar URL</Text>
+        <TextInput
+          style={[
+            styles.input,
+            { color: t.fg, borderColor: t.border, backgroundColor: t.surface },
+          ]}
+          value={picture}
+          onChangeText={setPicture}
+          placeholder="https://…"
+          placeholderTextColor={t.fgFaint}
+          autoCapitalize="none"
+          autoCorrect={false}
+        />
+
+        <TouchableOpacity
+          style={[
+            styles.saveBtn,
+            { backgroundColor: t.accent },
+            (updateProfile.isPending || !name.trim() || !picture.trim()) &&
+              styles.btnDisabled,
+          ]}
+          onPress={() => updateProfile.mutate()}
+          disabled={updateProfile.isPending || !name.trim() || !picture.trim()}
+          activeOpacity={0.85}
+        >
+          {updateProfile.isPending ? (
+            <ActivityIndicator size="small" color="#fff" />
+          ) : (
+            <Text style={styles.saveBtnText}>Save Changes</Text>
+          )}
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[styles.signOutBtn, { borderColor: t.border }]}
+          onPress={logout}
+          activeOpacity={0.85}
+        >
+          <Text style={[styles.signOutBtnText, { color: t.fg }]}>Sign Out</Text>
+        </TouchableOpacity>
+
+        <View style={[styles.dangerZone, { borderColor: destructive }]}>
+          <Text style={[styles.dangerTitle, { color: t.fg }]}>Danger Zone</Text>
+          <Text style={[styles.dangerDescription, { color: t.fgMuted }]}>
+            Permanently delete your account and all associated data, including
+            your library, watch history, and ratings.
+          </Text>
+          <TouchableOpacity
+            style={[styles.deleteBtn, { borderColor: destructive }]}
+            onPress={confirmDelete}
+            disabled={deleteAccount.isPending}
+            activeOpacity={0.85}
+          >
+            {deleteAccount.isPending ? (
+              <ActivityIndicator size="small" color={destructive} />
+            ) : (
+              <Text style={[styles.deleteBtnText, { color: destructive }]}>
+                Delete Account
+              </Text>
+            )}
+          </TouchableOpacity>
+        </View>
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 22,
+    paddingBottom: 16,
+    gap: 14,
+  },
+  backBtn: {
+    width: 32,
+    height: 32,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  backBtnText: {
+    fontSize: 28,
+    lineHeight: 28,
+  },
+  title: {
+    fontFamily: SERIF,
+    fontSize: 32,
+    letterSpacing: -0.5,
+  },
+  content: {
+    paddingHorizontal: 22,
+    paddingTop: 8,
+  },
+  avatarRow: {
+    alignItems: "center",
+    gap: 10,
+    marginBottom: 28,
+  },
+  avatar: {
+    width: 72,
+    height: 72,
+    borderRadius: 36,
+  },
+  avatarFallback: {
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  avatarFallbackText: {
+    fontFamily: SANS_700,
+    fontSize: 26,
+  },
+  email: {
+    fontFamily: SANS,
+    fontSize: 13,
+  },
+  label: {
+    fontFamily: SANS_600,
+    fontSize: 11,
+    letterSpacing: 0.4,
+    textTransform: "uppercase",
+    marginBottom: 6,
+    marginTop: 16,
+  },
+  input: {
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontFamily: SANS,
+    fontSize: 14.5,
+  },
+  saveBtn: {
+    marginTop: 24,
+    borderRadius: 10,
+    paddingVertical: 14,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  btnDisabled: {
+    opacity: 0.5,
+  },
+  saveBtnText: {
+    fontFamily: SANS_700,
+    fontSize: 14.5,
+    color: "#fff",
+  },
+  signOutBtn: {
+    marginTop: 12,
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingVertical: 14,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  signOutBtnText: {
+    fontFamily: SANS_600,
+    fontSize: 14.5,
+  },
+  dangerZone: {
+    marginTop: 32,
+    marginBottom: 40,
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 16,
+  },
+  dangerTitle: {
+    fontFamily: SANS_700,
+    fontSize: 15,
+    marginBottom: 6,
+  },
+  dangerDescription: {
+    fontFamily: SANS,
+    fontSize: 13,
+    lineHeight: 18,
+    marginBottom: 14,
+  },
+  deleteBtn: {
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingVertical: 12,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  deleteBtnText: {
+    fontFamily: SANS_700,
+    fontSize: 14,
+  },
+})

--- a/apps/mobile/components/PosterGrid.tsx
+++ b/apps/mobile/components/PosterGrid.tsx
@@ -19,6 +19,7 @@ import {
   SANS_600,
   SANS_700,
   MONO,
+  MONO_500,
 } from "../lib/theme"
 
 const TMDB_W342 = "https://image.tmdb.org/t/p/w342"
@@ -152,6 +153,7 @@ export function PosterGrid({
         const posterUri = show.posterPath
           ? `${TMDB_W342}${show.posterPath}`
           : null
+        const isCaughtUp = status === "caught_up"
         const progress =
           show.watchedEpisodes != null &&
           show.totalEpisodes != null &&
@@ -179,7 +181,17 @@ export function PosterGrid({
                   style={[styles.poster, { backgroundColor: t.surfaceAlt }]}
                 />
               )}
-              {hasProgress && progress != null && (
+              {isCaughtUp && show.nextEpisode && (
+                <View style={styles.upcomingBadge}>
+                  <Text style={styles.upcomingBadgeText}>
+                    S{show.nextEpisode.season}E{show.nextEpisode.episode}{" "}
+                    {show.nextEpisode.daysUntil === 0
+                      ? "today"
+                      : `in ${show.nextEpisode.daysUntil}d`}
+                  </Text>
+                </View>
+              )}
+              {!isCaughtUp && hasProgress && progress != null && (
                 <View style={styles.progressOverlay}>
                   <View style={styles.progressTrack}>
                     <View
@@ -191,7 +203,7 @@ export function PosterGrid({
                   </View>
                 </View>
               )}
-              {!hasProgress && show.totalEpisodes != null && (
+              {!isCaughtUp && !hasProgress && show.totalEpisodes != null && (
                 <View style={styles.epsBadge}>
                   <Text style={styles.epsBadgeText}>
                     {show.totalEpisodes} eps
@@ -284,6 +296,21 @@ const styles = StyleSheet.create({
     fontFamily: MONO,
     fontSize: 10,
     color: "#fff",
+  },
+  upcomingBadge: {
+    position: "absolute",
+    top: 8,
+    left: 8,
+    backgroundColor: "rgba(0,0,0,0.7)",
+    borderRadius: 6,
+    paddingHorizontal: 6,
+    paddingVertical: 3,
+  },
+  upcomingBadgeText: {
+    fontFamily: MONO_500,
+    fontSize: 9.5,
+    color: "#fff",
+    letterSpacing: 0.2,
   },
   title: {
     fontFamily: SANS_600,

--- a/apps/mobile/lib/auth.tsx
+++ b/apps/mobile/lib/auth.tsx
@@ -24,6 +24,7 @@ type AuthContextValue = {
   isLoading: boolean
   login: () => Promise<void>
   logout: () => Promise<void>
+  refreshUser: () => Promise<void>
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null)
@@ -110,7 +111,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <AuthContext.Provider value={{ user, isLoading, login, logout }}>
+    <AuthContext.Provider
+      value={{ user, isLoading, login, logout, refreshUser: syncUser }}
+    >
       {children}
     </AuthContext.Provider>
   )

--- a/apps/mobile/lib/config.ts
+++ b/apps/mobile/lib/config.ts
@@ -2,8 +2,11 @@ import Constants from "expo-constants"
 
 const extra = (Constants.expoConfig?.extra ?? {}) as Record<string, string>
 
+// EXPO_PUBLIC_API_URL takes priority so you can point a local build at a
+// local backend (e.g. `EXPO_PUBLIC_API_URL=http://localhost:3000 npm run ios`)
+// without editing app.json's extra.apiUrl.
 export const API_URL: string =
-  extra.apiUrl ?? process.env.EXPO_PUBLIC_API_URL ?? ""
+  process.env.EXPO_PUBLIC_API_URL ?? extra.apiUrl ?? ""
 export const AUTH0_DOMAIN: string =
   extra.auth0Domain ?? process.env.EXPO_PUBLIC_AUTH0_DOMAIN ?? ""
 export const AUTH0_CLIENT_ID: string =

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -17,6 +17,7 @@ import Watching from "@/pages/watching"
 import CaughtUp from "@/pages/caught-up"
 import Completed from "@/pages/completed"
 import ShowDetail from "@/pages/show-detail"
+import Profile from "@/pages/profile"
 import NotFound from "@/pages/not-found"
 
 const auth0Domain = import.meta.env.VITE_AUTH0_DOMAIN as string
@@ -32,6 +33,7 @@ function Router() {
       <Route path="/caught-up" component={CaughtUp} />
       <Route path="/completed" component={Completed} />
       <Route path="/show/:id" component={ShowDetail} />
+      <Route path="/profile" component={Profile} />
       <Route component={NotFound} />
     </Switch>
   )

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -202,7 +202,12 @@ export function AppSidebar() {
       <SidebarFooter className="p-4 border-t border-sidebar-border">
         {open ? (
           <>
-            <div className="flex items-center gap-3 mb-3">
+            <Link
+              href="/profile"
+              onClick={closeSidebar}
+              className="flex items-center gap-3 mb-3 rounded-md hover-elevate p-1 -m-1"
+              data-testid="link-profile"
+            >
               <Avatar className="w-8 h-8">
                 <AvatarImage src={user?.picture} alt={user?.name} />
                 <AvatarFallback className="bg-muted text-muted-foreground text-xs font-bold">
@@ -219,7 +224,7 @@ export function AppSidebar() {
                   {user?.email}
                 </p>
               </div>
-            </div>
+            </Link>
             <Button
               variant="outline"
               onClick={logout}
@@ -232,14 +237,16 @@ export function AppSidebar() {
           </>
         ) : (
           <div className="flex flex-col items-center gap-2">
-            <Avatar className="w-8 h-8">
-              <AvatarImage src={user?.picture} alt={user?.name} />
-              <AvatarFallback className="bg-muted text-muted-foreground text-xs font-bold">
-                {user?.name?.charAt(0).toUpperCase() || (
-                  <User className="w-4 h-4" />
-                )}
-              </AvatarFallback>
-            </Avatar>
+            <Link href="/profile" data-testid="link-profile">
+              <Avatar className="w-8 h-8">
+                <AvatarImage src={user?.picture} alt={user?.name} />
+                <AvatarFallback className="bg-muted text-muted-foreground text-xs font-bold">
+                  {user?.name?.charAt(0).toUpperCase() || (
+                    <User className="w-4 h-4" />
+                  )}
+                </AvatarFallback>
+              </Avatar>
+            </Link>
             <Button
               variant="ghost"
               size="icon"

--- a/apps/web/src/lib/auth.tsx
+++ b/apps/web/src/lib/auth.tsx
@@ -21,6 +21,7 @@ interface AuthContextType {
   isAuthenticated: boolean
   login: (options?: { signUp?: boolean }) => Promise<void>
   logout: () => Promise<void>
+  refreshUser: () => Promise<void>
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined)
@@ -99,6 +100,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         isAuthenticated: !!user,
         login,
         logout,
+        refreshUser: checkAuth,
       }}
     >
       {children}

--- a/apps/web/src/pages/profile.tsx
+++ b/apps/web/src/pages/profile.tsx
@@ -1,0 +1,155 @@
+import { useState } from "react"
+import { useMutation } from "@tanstack/react-query"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { User as UserIcon } from "lucide-react"
+import { useAuth } from "@/lib/auth"
+import { apiRequest } from "@/lib/queryClient"
+import { useToast } from "@/hooks/use-toast"
+
+export default function Profile() {
+  const { user, logout, refreshUser } = useAuth()
+  const { toast } = useToast()
+  const [name, setName] = useState(user?.name ?? "")
+  const [picture, setPicture] = useState(user?.picture ?? "")
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+
+  const updateProfile = useMutation({
+    mutationFn: () =>
+      apiRequest("PATCH", "/api/user/profile", { name, picture }),
+    onSuccess: async () => {
+      await refreshUser()
+      toast({ title: "Profile updated" })
+    },
+    onError: () => {
+      toast({ title: "Failed to update profile", variant: "destructive" })
+    },
+  })
+
+  const deleteAccount = useMutation({
+    mutationFn: () => apiRequest("DELETE", "/api/user"),
+    onSuccess: () => {
+      logout()
+    },
+    onError: () => {
+      toast({ title: "Failed to delete account", variant: "destructive" })
+      setDeleteDialogOpen(false)
+    },
+  })
+
+  return (
+    <div className="max-w-xl">
+      <div className="font-mono text-[11px] text-muted-foreground uppercase tracking-[0.14em] font-semibold mb-2">
+        Account
+      </div>
+      <h1 className="font-serif font-normal text-[56px] leading-none tracking-[-0.025em] text-foreground mb-8">
+        Profile
+      </h1>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Details</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-5">
+          <div className="flex items-center gap-4">
+            <Avatar className="w-14 h-14">
+              <AvatarImage src={picture} alt={name} />
+              <AvatarFallback className="bg-muted text-muted-foreground text-lg font-bold">
+                {name?.charAt(0).toUpperCase() || (
+                  <UserIcon className="w-6 h-6" />
+                )}
+              </AvatarFallback>
+            </Avatar>
+            <p className="text-sm text-muted-foreground">{user?.email}</p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="name">Name</Label>
+            <Input
+              id="name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              data-testid="input-profile-name"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="picture">Avatar URL</Label>
+            <Input
+              id="picture"
+              value={picture}
+              onChange={(e) => setPicture(e.target.value)}
+              data-testid="input-profile-picture"
+            />
+          </div>
+
+          <Button
+            onClick={() => updateProfile.mutate()}
+            disabled={
+              updateProfile.isPending || !name.trim() || !picture.trim()
+            }
+            data-testid="button-save-profile"
+          >
+            {updateProfile.isPending ? "Saving..." : "Save Changes"}
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card className="mt-6 border-destructive-border">
+        <CardHeader>
+          <CardTitle>Danger Zone</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground mb-4">
+            Permanently delete your account and all associated data, including
+            your library, watch history, and ratings. This cannot be undone.
+          </p>
+          <Button
+            variant="destructive"
+            onClick={() => setDeleteDialogOpen(true)}
+            data-testid="button-delete-account"
+          >
+            Delete Account
+          </Button>
+        </CardContent>
+      </Card>
+
+      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete your account?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete your account, library, and watch
+              history. This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel data-testid="button-cancel-delete">
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => deleteAccount.mutate()}
+              disabled={deleteAccount.isPending}
+              data-testid="button-confirm-delete"
+            >
+              {deleteAccount.isPending ? "Deleting..." : "Delete Account"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18854,7 +18854,9 @@
       "name": "@showtracker/api-client",
       "version": "1.0.0",
       "peerDependencies": {
-        "@tanstack/react-query": "^5"
+        "@showtracker/shared": "*",
+        "@tanstack/react-query": "^5",
+        "react": ">=18"
       }
     },
     "packages/shared": {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -268,13 +268,33 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
         let episodesWatched = 0
         if (activeShowIds.length > 0) {
-          const { count } = await supabase
+          const { data: watchedRows } = await supabase
             .from("watch_progress")
-            .select("*", { count: "exact", head: true })
+            .select("show_id, season_number, episode_number")
             .eq("user_id", req.userId)
             .eq("watched", true)
             .in("show_id", activeShowIds)
-          episodesWatched = count || 0
+
+          if (watchedRows && watchedRows.length > 0) {
+            const now = new Date().toISOString()
+            const { data: airedEpisodes } = await supabase
+              .from("episodes")
+              .select("show_id, season_number, episode_number")
+              .in("show_id", activeShowIds)
+              .lte("air_date", now)
+              .not("air_date", "is", null)
+
+            const airedKeys = new Set(
+              (airedEpisodes || []).map(
+                (e) => `${e.show_id}-${e.season_number}-${e.episode_number}`
+              )
+            )
+            episodesWatched = watchedRows.filter((w) =>
+              airedKeys.has(
+                `${w.show_id}-${w.season_number}-${w.episode_number}`
+              )
+            ).length
+          }
         }
 
         const stats = {
@@ -1402,16 +1422,23 @@ async function markShowEpisodesWatched(
     const allEpisodes: Array<{ seasonNumber: number; episodeNumber: number }> =
       []
 
+    const now = new Date()
     for (let seasonNum = 1; seasonNum <= show.number_of_seasons; seasonNum++) {
       try {
         const seasonData = await getTVShowSeason(showId, seasonNum)
         if (seasonData.episodes && seasonData.episodes.length > 0) {
-          seasonData.episodes.forEach((episode: any) => {
-            allEpisodes.push({
-              seasonNumber: seasonNum,
-              episodeNumber: episode.episode_number,
+          // Only mark aired episodes
+          seasonData.episodes
+            .filter(
+              (episode: any) =>
+                episode.air_date && new Date(episode.air_date) <= now
+            )
+            .forEach((episode: any) => {
+              allEpisodes.push({
+                seasonNumber: seasonNum,
+                episodeNumber: episode.episode_number,
+              })
             })
-          })
         }
       } catch (error) {
         console.error(

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -187,6 +187,77 @@ export async function registerRoutes(app: Express): Promise<Server> {
     res.json({ message: "Logged out" })
   })
 
+  // Update profile details (name, avatar)
+  app.patch(
+    "/api/user/profile",
+    authMiddleware,
+    async (req: AuthRequest, res: Response) => {
+      try {
+        const { name, picture } = req.body as {
+          name?: string
+          picture?: string
+        }
+
+        const updates: Record<string, string> = {}
+        if (name !== undefined) {
+          if (typeof name !== "string" || !name.trim()) {
+            return res.status(400).json({ message: "Invalid name" })
+          }
+          updates.name = name.trim()
+        }
+        if (picture !== undefined) {
+          if (typeof picture !== "string" || !picture.trim()) {
+            return res.status(400).json({ message: "Invalid picture" })
+          }
+          updates.picture = picture.trim()
+        }
+
+        if (Object.keys(updates).length === 0) {
+          return res.status(400).json({ message: "No fields to update" })
+        }
+
+        const { data: user, error } = await supabase
+          .from("users")
+          .update(updates)
+          .eq("id", req.userId)
+          .select()
+          .single()
+
+        if (error || !user) {
+          return res.status(500).json({ message: "Failed to update profile" })
+        }
+
+        res.json({ user })
+      } catch (error) {
+        console.error("Update profile error:", error)
+        res.status(500).json({ message: "Failed to update profile" })
+      }
+    }
+  )
+
+  // Delete account (cascades to user_shows, watch_progress, device_tokens, user_credentials)
+  app.delete(
+    "/api/user",
+    authMiddleware,
+    async (req: AuthRequest, res: Response) => {
+      try {
+        const { error } = await supabase
+          .from("users")
+          .delete()
+          .eq("id", req.userId)
+
+        if (error) {
+          return res.status(500).json({ message: "Failed to delete account" })
+        }
+
+        res.json({ message: "Account deleted" })
+      } catch (error) {
+        console.error("Delete account error:", error)
+        res.status(500).json({ message: "Failed to delete account" })
+      }
+    }
+  )
+
   // Register mobile push notification token
   app.post(
     "/api/devices/register",

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1211,14 +1211,34 @@ async function batchShowProgress(
     )
   }
 
+  const now = new Date().toISOString()
+
   return userShows.map((us) => {
     const show = us.shows ?? showsById[us.show_id] ?? {}
     const watched = watchedByShow[us.show_id] ?? new Set()
-    const watchedEpisodes = watched.size
-    const totalEpisodes = (show.number_of_episodes as number) || 1
-    const progress = (watchedEpisodes / totalEpisodes) * 100
 
     const episodes = episodesByShow[us.show_id]
+    const airedKeys = episodes
+      ? new Set(
+          episodes
+            .filter(
+              (ep) =>
+                ep.season_number !== 0 && ep.air_date && ep.air_date <= now
+            )
+            .map((ep) => `${ep.season_number}-${ep.episode_number}`)
+        )
+      : null
+
+    // Fall back to the unfiltered TMDB episode count if we don't have
+    // cached episodes yet, so we don't regress to "0/1" for such shows.
+    const watchedEpisodes = airedKeys
+      ? Array.from(watched).filter((key) => airedKeys.has(key)).length
+      : watched.size
+    const totalEpisodes = airedKeys
+      ? airedKeys.size || 1
+      : (show.number_of_episodes as number) || 1
+    const progress = (watchedEpisodes / totalEpisodes) * 100
+
     let nextEpisode: {
       season: number
       episode: number
@@ -1451,21 +1471,37 @@ async function findNextUnwatchedEpisode(userId: string, showId: number) {
 }
 
 async function calculateShowProgress(userId: string, showId: number) {
-  const { data: show } = await supabase
-    .from("shows")
-    .select("number_of_episodes")
-    .eq("id", showId)
-    .single()
+  const now = new Date().toISOString()
+  const fetchAiredEpisodes = () =>
+    supabase
+      .from("episodes")
+      .select("season_number, episode_number")
+      .eq("show_id", showId)
+      .neq("season_number", 0)
+      .lte("air_date", now)
+      .not("air_date", "is", null)
+
+  let { data: airedEpisodes } = await fetchAiredEpisodes()
+  if (!airedEpisodes || airedEpisodes.length === 0) {
+    await ensureEpisodesCached(showId)
+    const r = await fetchAiredEpisodes()
+    airedEpisodes = r.data
+  }
 
   const { data: progress } = await supabase
     .from("watch_progress")
-    .select("*")
+    .select("season_number, episode_number")
     .eq("user_id", userId)
     .eq("show_id", showId)
     .eq("watched", true)
 
-  const watchedEpisodes = progress?.length || 0
-  const totalEpisodes = show?.number_of_episodes || 1
+  const airedKeys = new Set(
+    (airedEpisodes || []).map((e) => `${e.season_number}-${e.episode_number}`)
+  )
+  const watchedEpisodes = (progress || []).filter((p) =>
+    airedKeys.has(`${p.season_number}-${p.episode_number}`)
+  ).length
+  const totalEpisodes = airedKeys.size || 1
   const progressPercent = (watchedEpisodes / totalEpisodes) * 100
 
   // Find next unwatched episode

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -699,12 +699,20 @@ export async function registerRoutes(app: Express): Promise<Server> {
           .eq("id", parseInt(id))
           .single()
 
-        if (!show || !show.number_of_seasons) {
+        let numberOfSeasons = show?.number_of_seasons
+        if (!numberOfSeasons) {
+          // Show hasn't been cached locally yet (e.g. viewed before being
+          // added to a collection) — fall back to TMDB, same as /api/shows/:id
+          const tmdbShow = await getTVShowDetails(parseInt(id))
+          numberOfSeasons = tmdbShow.number_of_seasons
+        }
+
+        if (!numberOfSeasons) {
           return res.json([])
         }
 
         const seasonNums = Array.from(
-          { length: show.number_of_seasons },
+          { length: numberOfSeasons },
           (_, i) => i + 1
         )
 


### PR DESCRIPTION
## Summary
- Watching count (both the aggregate stat and per-show progress like "82/92 eps") no longer includes episodes that haven't aired yet, on both web and mobile.
- Fixed a bug where a show's season/episode info failed to load ("No episode information available") if it was viewed before being added to a collection.
- Added a profile page on web and mobile to edit name/avatar and delete an account (hard delete, no Auth0 Management API call — see commit message for why).
- Mobile: fixed the "next episode" pill missing from the `/caught-up` library tab (it only rendered on the home screen), and made `EXPO_PUBLIC_API_URL` override `app.json`'s `apiUrl` so local builds can point at a local backend.
- Documented the native dev-client workflow for git worktrees in the README.

## Test plan
- [x] `npm run check` (root: server/web/api/packages) passes clean
- [x] `eslint` clean on all changed files (pre-existing `any` warnings untouched)
- [x] Manual QA on web: watching count excludes unaired episodes, season data loads for an uncollected show, profile edit/delete/sign-out flows
- [x] Manual QA on mobile (iOS simulator): same three flows, plus the caught-up next-episode pill and local API URL override

🤖 Generated with [Claude Code](https://claude.com/claude-code)