### PR TITLE
Reset search on tab re-tap, add pull-to-refresh

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -1,10 +1,11 @@
-import React from "react"
+import React, { useState } from "react"
 import {
   ScrollView,
   View,
   StyleSheet,
   ImageBackground,
   TouchableOpacity,
+  RefreshControl,
 } from "react-native"
 import { Text, ActivityIndicator } from "react-native-paper"
 import { LinearGradient } from "expo-linear-gradient"
@@ -325,20 +326,44 @@ export default function DashboardScreen() {
   const t = useAppTheme()
   const qc = useQueryClient()
 
-  const { data: stats } = useQuery<ShowStats>({ queryKey: ["/api/stats"] })
+  const [refreshing, setRefreshing] = useState(false)
 
-  const { data: watching, isLoading: watchingLoading } =
-    useQuery<PaginatedShowsResponse>({
-      queryKey: [`/api/shows/watching?page=1&limit=${DASHBOARD_LIMIT}`],
-    })
-  const { data: wantToWatch, isLoading: wtwLoading } =
-    useQuery<PaginatedShowsResponse>({
-      queryKey: [`/api/shows/want-to-watch?page=1&limit=${DASHBOARD_LIMIT}`],
-    })
-  const { data: caughtUp, isLoading: cuLoading } =
-    useQuery<PaginatedShowsResponse>({
-      queryKey: [`/api/shows/caught-up?page=1&limit=${DASHBOARD_LIMIT}`],
-    })
+  const { data: stats, refetch: refetchStats } = useQuery<ShowStats>({
+    queryKey: ["/api/stats"],
+  })
+
+  const {
+    data: watching,
+    isLoading: watchingLoading,
+    refetch: refetchWatching,
+  } = useQuery<PaginatedShowsResponse>({
+    queryKey: [`/api/shows/watching?page=1&limit=${DASHBOARD_LIMIT}`],
+  })
+  const {
+    data: wantToWatch,
+    isLoading: wtwLoading,
+    refetch: refetchWantToWatch,
+  } = useQuery<PaginatedShowsResponse>({
+    queryKey: [`/api/shows/want-to-watch?page=1&limit=${DASHBOARD_LIMIT}`],
+  })
+  const {
+    data: caughtUp,
+    isLoading: cuLoading,
+    refetch: refetchCaughtUp,
+  } = useQuery<PaginatedShowsResponse>({
+    queryKey: [`/api/shows/caught-up?page=1&limit=${DASHBOARD_LIMIT}`],
+  })
+
+  const onRefresh = async () => {
+    setRefreshing(true)
+    await Promise.all([
+      refetchStats(),
+      refetchWatching(),
+      refetchWantToWatch(),
+      refetchCaughtUp(),
+    ])
+    setRefreshing(false)
+  }
 
   const featuredShow = watching?.shows?.[0]
 
@@ -370,6 +395,14 @@ export default function DashboardScreen() {
     <ScrollView
       style={{ backgroundColor: t.bg }}
       contentContainerStyle={{ paddingBottom: 32 }}
+      refreshControl={
+        <RefreshControl
+          refreshing={refreshing}
+          onRefresh={onRefresh}
+          tintColor={t.fg}
+          colors={[t.fg]}
+        />
+      }
     >
       {featuredShow ? (
         <HeroSection

--- a/apps/mobile/app/(tabs)/search.tsx
+++ b/apps/mobile/app/(tabs)/search.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useRef } from "react"
+import React, { useState, useMemo, useRef, useEffect } from "react"
 import { useDebounce } from "@showtracker/api-client"
 import {
   View,
@@ -16,7 +16,7 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query"
-import { useRouter } from "expo-router"
+import { useRouter, useNavigation } from "expo-router"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { apiRequest } from "@showtracker/api-client"
 import type { TMDBShow, UserShow, SearchResponse } from "@showtracker/shared"
@@ -202,6 +202,16 @@ export default function SearchScreen() {
   const qc = useQueryClient()
   const insets = useSafeAreaInsets()
   const inputRef = useRef<TextInput>(null)
+  const navigation = useNavigation()
+
+  useEffect(() => {
+    return (navigation as any).addListener("tabPress", () => {
+      if (navigation.isFocused()) {
+        setQuery("")
+        inputRef.current?.blur()
+      }
+    })
+  }, [navigation])
 
   const { data, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } =
     useInfiniteQuery<SearchResponse>({

--- a/apps/mobile/components/LibraryScreen.tsx
+++ b/apps/mobile/components/LibraryScreen.tsx
@@ -53,6 +53,8 @@ export function LibraryScreen({ endpoint, status }: Props) {
         status={status}
         onEndReached={lib.onEndReached}
         isFetchingNextPage={lib.isFetchingNextPage}
+        onRefresh={lib.refetch}
+        refreshing={lib.isRefetching}
       />
     </View>
   )

--- a/apps/mobile/components/PosterGrid.tsx
+++ b/apps/mobile/components/PosterGrid.tsx
@@ -8,6 +8,7 @@ import {
   Dimensions,
   Text,
   ActivityIndicator,
+  RefreshControl,
 } from "react-native"
 import { useRouter } from "expo-router"
 import type { ShowWithProgress } from "@showtracker/shared"
@@ -34,6 +35,8 @@ type Props = {
   emptyMessage?: string
   onEndReached?: () => void
   isFetchingNextPage?: boolean
+  onRefresh?: () => void
+  refreshing?: boolean
 }
 
 function SkeletonCard() {
@@ -116,6 +119,8 @@ export function PosterGrid({
   status,
   onEndReached,
   isFetchingNextPage,
+  onRefresh,
+  refreshing,
 }: Props) {
   const t = useAppTheme()
   const router = useRouter()
@@ -144,6 +149,16 @@ export function PosterGrid({
       style={styles.list}
       onEndReached={onEndReached}
       onEndReachedThreshold={0.3}
+      refreshControl={
+        onRefresh ? (
+          <RefreshControl
+            refreshing={!!refreshing}
+            onRefresh={onRefresh}
+            tintColor={t.fg}
+            colors={[t.fg]}
+          />
+        ) : undefined
+      }
       ListFooterComponent={
         isFetchingNextPage ? (
           <ActivityIndicator style={styles.footerLoader} color={t.fgMuted} />

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -88,19 +88,26 @@ export function useLibraryShows(endpoint: string) {
   const [search, setSearch] = useState("")
   const debouncedSearch = useDebounce(search, 350)
 
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
-    useInfiniteQuery<PaginatedShowsResponse>({
-      queryKey: [endpoint, debouncedSearch],
-      queryFn: async ({ pageParam = 1 }) => {
-        const qs = new URLSearchParams({ page: String(pageParam), limit: "20" })
-        if (debouncedSearch) qs.set("search", debouncedSearch)
-        const res = await apiRequest("GET", `${endpoint}?${qs}`)
-        return res.json()
-      },
-      getNextPageParam: (last) =>
-        last.page < last.totalPages ? last.page + 1 : undefined,
-      initialPageParam: 1,
-    })
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+    refetch,
+    isRefetching,
+  } = useInfiniteQuery<PaginatedShowsResponse>({
+    queryKey: [endpoint, debouncedSearch],
+    queryFn: async ({ pageParam = 1 }) => {
+      const qs = new URLSearchParams({ page: String(pageParam), limit: "20" })
+      if (debouncedSearch) qs.set("search", debouncedSearch)
+      const res = await apiRequest("GET", `${endpoint}?${qs}`)
+      return res.json()
+    },
+    getNextPageParam: (last) =>
+      last.page < last.totalPages ? last.page + 1 : undefined,
+    initialPageParam: 1,
+  })
 
   const shows = useMemo(() => data?.pages.flatMap((p) => p.shows) ?? [], [data])
   const total = data?.pages[0]?.total ?? 0
@@ -112,6 +119,8 @@ export function useLibraryShows(endpoint: string) {
     hasNextPage: hasNextPage ?? false,
     isFetchingNextPage,
     fetchNextPage,
+    refetch,
+    isRefetching,
     search,
     setSearch,
   }


### PR DESCRIPTION
## Summary
- Search query/results previously persisted forever across tab switches. Tapping the already-active Search tab now clears the query and dismisses the keyboard (tap-active-tab-to-reset), while switching away and back still preserves your search — matches the behavior agreed on with the user.
- Added pull-to-refresh (`RefreshControl`) to the Home dashboard (stats + all three carousels) and to all Library tabs (watching/want-to-watch/caught-up/completed), since there was previously no way to force a data refresh. Wired through the existing `refetch`/`isRefetching` from React Query — no new fetch logic.

## Changes
- `apps/mobile/app/(tabs)/search.tsx`: listens for `tabPress` on the focused tab, clears query + blurs input
- `apps/mobile/app/(tabs)/index.tsx`: `RefreshControl` on the dashboard `ScrollView`, refetches all 4 dashboard queries in parallel
- `packages/api-client/src/index.ts`: `useLibraryShows` now exposes `refetch`/`isRefetching`
- `apps/mobile/components/LibraryScreen.tsx`, `apps/mobile/components/PosterGrid.tsx`: thread `onRefresh`/`refreshing` into the `FlatList`'s `RefreshControl`

## Test plan
- [x] `tsc --noEmit` passes on `apps/mobile` and the root/web workspace
- [ ] Manual check in Expo simulator: type a search, switch to another tab and back (query persists), then tap Search tab icon again while already on it (query clears)
- [ ] Manual check: pull down on Home and each Library tab, confirm spinner + refreshed data