### PR TITLE
Re-check completed shows for renewals in status refresh

### DIFF
--- a/apps/web/src/components/status-validation-trigger.tsx
+++ b/apps/web/src/components/status-validation-trigger.tsx
@@ -4,8 +4,10 @@ import { apiRequest, queryClient } from "@/lib/queryClient"
 
 const STORAGE_KEY_INITIAL = "statusValidationInitial"
 const STORAGE_KEY_NAV = "statusValidationNav"
+const STORAGE_KEY_COMPLETED_RECHECK = "statusValidationCompletedRecheck"
 const THROTTLE_INITIAL_MS = 30 * 60 * 1000 // 30 minutes
 const THROTTLE_NAV_MS = 10 * 60 * 1000 // 10 minutes
+const THROTTLE_COMPLETED_RECHECK_MS = 24 * 60 * 60 * 1000 // 24 hours
 export const STATUS_INVALIDATE_DELAY_MS = 60 * 1000 // 1 minute - give backend time to finish
 
 export function invalidateStatusRelatedQueries() {
@@ -20,7 +22,7 @@ export function invalidateStatusRelatedQueries() {
 }
 
 function tryRun(
-  scope: "all" | "caught_up_only",
+  scope: "all" | "caught_up_only" | "completed_recheck",
   storageKey: string,
   throttleMs: number
 ): void {
@@ -47,6 +49,13 @@ export function StatusValidationTrigger() {
   // Initial load: refresh all non-completed shows (throttled 30 min)
   useEffect(() => {
     tryRun("all", STORAGE_KEY_INITIAL, THROTTLE_INITIAL_MS)
+    // Also periodically re-check completed shows in case one was renewed
+    // (throttled much longer since this rarely matters)
+    tryRun(
+      "completed_recheck",
+      STORAGE_KEY_COMPLETED_RECHECK,
+      THROTTLE_COMPLETED_RECHECK_MS
+    )
   }, [])
 
   // On navigation: refresh all non-completed shows (throttled 10 min, separate from initial)

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -428,7 +428,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     authMiddleware,
     async (req: AuthRequest, res: Response) => {
       const scope = req.body?.scope ?? "all"
-      const validScopes = new Set(["all", "caught_up_only"])
+      const validScopes = new Set(["all", "caught_up_only", "completed_recheck"])
       if (!validScopes.has(scope)) {
         return res.status(400).json({ message: "Invalid scope" })
       }
@@ -1022,24 +1022,32 @@ async function runValidateStatusJob({
 }: {
   runId: string
   userId: string
-  scope: "all" | "caught_up_only"
+  scope: "all" | "caught_up_only" | "completed_recheck"
   targetShowId?: number
 }) {
   const runStartMs = Date.now()
   try {
     console.log(`[validate-status:${runId}] run started`)
 
+    const isTargetedShow = targetShowId !== undefined
+
     let query = supabase
       .from("user_shows")
       .select("show_id")
       .eq("user_id", userId)
-      .neq("status", "completed")
       .neq("status", "stopped")
 
     if (scope === "caught_up_only") {
       query = query.eq("status", "caught_up")
+    } else if (scope === "completed_recheck") {
+      query = query.eq("status", "completed")
+    } else if (!isTargetedShow) {
+      // Bulk "all" sweeps skip completed shows (they rarely change); a
+      // targeted single-show check (e.g. from the show detail page) still
+      // re-validates a completed show in case it was renewed.
+      query = query.neq("status", "completed")
     }
-    if (targetShowId !== undefined) {
+    if (isTargetedShow) {
       query = query.eq("show_id", targetShowId)
     }
 


### PR DESCRIPTION
## Summary
- Completed shows were unconditionally excluded from the background status validation job (`runValidateStatusJob` in [server/routes.ts](server/routes.ts)), so a show that got renewed on TMDB after being marked `completed` never had its status re-evaluated.
- A targeted single-show check (e.g. visiting a show's detail page) now still validates a completed show, in case it was renewed.
- Added a new `completed_recheck` scope that re-validates all of a user's completed shows, triggered once per 24 hours from [status-validation-trigger.tsx](apps/web/src/components/status-validation-trigger.tsx) alongside the existing initial-load sweep.
- The frequent nav/initial-load `"all"` sweep (throttled 10–30 min) still skips completed shows, so no extra TMDB load is added to the common path.

## Why
Reported by the user: a show they'd marked completed was renewed by the network, but the app never picked up the change since completed shows were fully excluded from every status-refresh path, including per-show checks.

## Test plan
- [x] `npm run check` passes (verified via `npx tsc` after `npm ci`)
- [ ] Manually mark a show completed, then simulate a TMDB renewal (or wait for a real one) and confirm the show detail page check and/or the daily `completed_recheck` sweep flips its status back to `watching`/`caught_up`

Note: the pre-commit hook (`.husky/pre-commit`) currently fails to execute on this machine due to CRLF line endings / missing shebang — a pre-existing issue unrelated to this change. This commit was made with `--no-verify` after confirming with the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)