### PR TITLE
Add full "stopped" show feature across web and mobile

### DIFF
--- a/apps/mobile/app/(tabs)/library/_layout.tsx
+++ b/apps/mobile/app/(tabs)/library/_layout.tsx
@@ -45,6 +45,13 @@ const TABS = [
     segment: "completed",
     apiKey: "/api/shows/completed?page=1&limit=1",
   },
+  {
+    id: "stopped",
+    label: "Stopped",
+    href: "/(tabs)/library/stopped",
+    segment: "stopped",
+    apiKey: "/api/shows/stopped?page=1&limit=1",
+  },
 ] as const
 
 type TabId = (typeof TABS)[number]["id"]
@@ -81,12 +88,16 @@ export default function LibraryLayout() {
   const { data: compData } = useQuery<ShowsResponse>({
     queryKey: ["/api/shows/completed?page=1&limit=1"],
   })
+  const { data: stoppedData } = useQuery<ShowsResponse>({
+    queryKey: ["/api/shows/stopped?page=1&limit=1"],
+  })
 
   const totals: Record<TabId, number | undefined> = {
     watching: watchingData?.total,
     want_to_watch: wtwData?.total,
     caught_up: cuData?.total,
     completed: compData?.total,
+    stopped: stoppedData?.total,
   }
 
   const activeTab = TABS.find((tab) => pathname.includes(tab.segment))

--- a/apps/mobile/app/(tabs)/library/stopped.tsx
+++ b/apps/mobile/app/(tabs)/library/stopped.tsx
@@ -1,0 +1,6 @@
+import React from "react"
+import { LibraryScreen } from "../../../components/LibraryScreen"
+
+export default function StoppedScreen() {
+  return <LibraryScreen endpoint="/api/shows/stopped" status="stopped" />
+}

--- a/apps/mobile/app/shows/[id].tsx
+++ b/apps/mobile/app/shows/[id].tsx
@@ -45,6 +45,14 @@ const STATUSES: { value: StatusKey; label: string }[] = [
   { value: "stopped", label: "Stopped" },
 ]
 
+const LIBRARY_ENDPOINTS = [
+  "/api/shows/watching",
+  "/api/shows/want-to-watch",
+  "/api/shows/caught-up",
+  "/api/shows/completed",
+  "/api/shows/stopped",
+]
+
 export default function ShowDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>()
   const router = useRouter()
@@ -79,6 +87,10 @@ export default function ShowDetailScreen() {
     qc.invalidateQueries({ queryKey: ["/api/shows", id] })
     qc.invalidateQueries({ queryKey: ["/api/shows", id, "progress"] })
     qc.invalidateQueries({ queryKey: ["/api/stats"] })
+    for (const endpoint of LIBRARY_ENDPOINTS) {
+      qc.invalidateQueries({ queryKey: [endpoint] })
+      qc.invalidateQueries({ queryKey: [`${endpoint}?page=1&limit=1`] })
+    }
   }
 
   useEffect(() => {
@@ -170,7 +182,7 @@ export default function ShowDetailScreen() {
 
   const updateStatus = useMutation({
     mutationFn: (status: string) =>
-      apiRequest("POST", "/api/user/shows", { showId: Number(id), status }),
+      apiRequest("PATCH", `/api/user/shows/${id}`, { status }),
     onSuccess: invalidateShow,
   })
 
@@ -341,6 +353,16 @@ export default function ShowDetailScreen() {
               <Text style={styles.addBtnText}>Add to Collection</Text>
             )}
           </TouchableOpacity>
+        </View>
+      )}
+
+      {/* Stopped explanation */}
+      {isInCollection && currentStatus === "stopped" && (
+        <View style={styles.actionBlock}>
+          <Text style={{ color: t.fgMuted, fontFamily: SANS, fontSize: 13.5 }}>
+            You've stopped tracking this show. Your progress is saved. Mark an
+            episode as watched below to start tracking again.
+          </Text>
         </View>
       )}
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -16,6 +16,7 @@ import WantToWatch from "@/pages/want-to-watch"
 import Watching from "@/pages/watching"
 import CaughtUp from "@/pages/caught-up"
 import Completed from "@/pages/completed"
+import Stopped from "@/pages/stopped"
 import ShowDetail from "@/pages/show-detail"
 import Profile from "@/pages/profile"
 import NotFound from "@/pages/not-found"
@@ -32,6 +33,7 @@ function Router() {
       <Route path="/watching" component={Watching} />
       <Route path="/caught-up" component={CaughtUp} />
       <Route path="/completed" component={Completed} />
+      <Route path="/stopped" component={Stopped} />
       <Route path="/show/:id" component={ShowDetail} />
       <Route path="/profile" component={Profile} />
       <Route component={NotFound} />

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -31,6 +31,7 @@ const libraryItems: { title: string; url: string; status: StatusKey }[] = [
   { title: "Watching", url: "/watching", status: "watching" },
   { title: "Caught Up", url: "/caught-up", status: "caught_up" },
   { title: "Completed", url: "/completed", status: "completed" },
+  { title: "Stopped", url: "/stopped", status: "stopped" },
 ]
 
 function StatusDot({ status }: { status: StatusKey }) {
@@ -64,6 +65,7 @@ export function AppSidebar() {
     completedShows: number
     wantToWatchShows: number
     caughtUpShows: number
+    stoppedShows: number
     episodesWatched: number
   }>({ queryKey: ["/api/stats"] })
 
@@ -72,7 +74,7 @@ export function AppSidebar() {
     completed: stats?.completedShows,
     want_to_watch: stats?.wantToWatchShows,
     caught_up: stats?.caughtUpShows,
-    stopped: undefined,
+    stopped: stats?.stoppedShows,
   }
 
   const logoIcon = (

--- a/apps/web/src/pages/library-view.tsx
+++ b/apps/web/src/pages/library-view.tsx
@@ -18,6 +18,7 @@ const TABS: TabConfig[] = [
   { id: "want_to_watch", label: "Want to Watch", href: "/want-to-watch" },
   { id: "caught_up", label: "Caught Up", href: "/caught-up" },
   { id: "completed", label: "Completed", href: "/completed" },
+  { id: "stopped", label: "Stopped", href: "/stopped" },
 ]
 
 interface LibraryViewProps {

--- a/apps/web/src/pages/show-detail.tsx
+++ b/apps/web/src/pages/show-detail.tsx
@@ -99,6 +99,7 @@ export default function ShowDetail() {
     queryClient.invalidateQueries({ queryKey: ["/api/shows/caught-up"] })
     queryClient.invalidateQueries({ queryKey: ["/api/shows/completed"] })
     queryClient.invalidateQueries({ queryKey: ["/api/shows/want-to-watch"] })
+    queryClient.invalidateQueries({ queryKey: ["/api/shows/stopped"] })
   }
 
   const toggleEpisodeMutation = useMutation({
@@ -138,6 +139,7 @@ export default function ShowDetail() {
       queryClient.invalidateQueries({ queryKey: ["/api/shows/caught-up"] })
       queryClient.invalidateQueries({ queryKey: ["/api/shows/completed"] })
       queryClient.invalidateQueries({ queryKey: ["/api/shows/want-to-watch"] })
+      queryClient.invalidateQueries({ queryKey: ["/api/shows/stopped"] })
       const statusLabel =
         variables.initialStatus === "completed"
           ? "Completed"
@@ -168,12 +170,13 @@ export default function ShowDetail() {
       queryClient.invalidateQueries({ queryKey: ["/api/shows/caught-up"] })
       queryClient.invalidateQueries({ queryKey: ["/api/shows/completed"] })
       queryClient.invalidateQueries({ queryKey: ["/api/shows/want-to-watch"] })
-      toast({ title: "Removed from collection" })
+      queryClient.invalidateQueries({ queryKey: ["/api/shows/stopped"] })
+      toast({ title: "Marked as stopped" })
     },
     onError: () =>
       toast({
         title: "Error",
-        description: "Failed to remove show.",
+        description: "Failed to mark show as stopped.",
         variant: "destructive",
       }),
   })
@@ -619,9 +622,9 @@ export default function ShowDetail() {
                 className="text-muted-foreground hover:text-destructive"
                 disabled={removeShowMutation.isPending}
                 onClick={() => setRemoveShowDialogOpen(true)}
-                data-testid="button-remove-from-collection"
+                data-testid="button-mark-as-stopped"
               >
-                Remove from collection
+                Mark as Stopped
               </Button>
             )}
             {show.userShow?.status === "stopped" && (
@@ -891,9 +894,9 @@ export default function ShowDetail() {
       >
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Remove from collection?</AlertDialogTitle>
+            <AlertDialogTitle>Mark as stopped?</AlertDialogTitle>
             <AlertDialogDescription>
-              This will remove the show from your list. Your watch progress is
+              This moves the show to your Stopped list. Your watch progress is
               kept; mark an episode as watched to start tracking again.
             </AlertDialogDescription>
           </AlertDialogHeader>
@@ -903,9 +906,9 @@ export default function ShowDetail() {
               onClick={() => removeShowMutation.mutate()}
               disabled={removeShowMutation.isPending}
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-              data-testid="button-confirm-remove-from-collection"
+              data-testid="button-confirm-mark-as-stopped"
             >
-              Remove
+              Mark as Stopped
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/apps/web/src/pages/stopped.tsx
+++ b/apps/web/src/pages/stopped.tsx
@@ -1,0 +1,25 @@
+import { LibraryView } from "./library-view"
+import { useLibraryShows } from "@/hooks/use-library-shows"
+
+export default function Stopped() {
+  const lib = useLibraryShows("/api/shows/stopped")
+
+  return (
+    <LibraryView
+      activeTab="stopped"
+      shows={lib.shows}
+      isLoading={lib.isLoading}
+      total={lib.total}
+      hasNextPage={lib.hasNextPage}
+      isFetchingNextPage={lib.isFetchingNextPage}
+      observerTarget={lib.observerTarget}
+      filterValue={lib.search}
+      onFilterChange={lib.setSearch}
+      emptyMessage={
+        <p className="text-muted-foreground col-span-full py-8">
+          No stopped shows. Shows you stop tracking will show up here.
+        </p>
+      }
+    />
+  )
+}

--- a/database-schema.sql
+++ b/database-schema.sql
@@ -40,7 +40,7 @@ CREATE TABLE IF NOT EXISTS user_shows (
   id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
   user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   show_id INTEGER NOT NULL REFERENCES shows(id) ON DELETE CASCADE,
-  status TEXT NOT NULL CHECK (status IN ('want_to_watch', 'watching', 'completed', 'caught_up')),
+  status TEXT NOT NULL CHECK (status IN ('want_to_watch', 'watching', 'completed', 'caught_up', 'stopped')),
   rating INTEGER CHECK (rating >= 1 AND rating <= 10),
   notes TEXT,
   added_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -386,6 +386,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
             activeShows.filter(
               (s: { status: string }) => s.status === "caught_up"
             ).length || 0,
+          stoppedShows:
+            (userShows || []).filter(
+              (s: { status: string }) => s.status === "stopped"
+            ).length || 0,
           episodesWatched,
         }
 
@@ -537,6 +541,50 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   )
 
+  // Explicitly set a show's status (e.g. mark as stopped, resume watching)
+  app.patch(
+    "/api/user/shows/:showId",
+    authMiddleware,
+    async (req: AuthRequest, res: Response) => {
+      try {
+        const showId = parseInt(req.params.showId, 10)
+        if (Number.isNaN(showId)) {
+          return res.status(400).json({ message: "Invalid show ID" })
+        }
+
+        const validStatuses = [
+          "want_to_watch",
+          "watching",
+          "caught_up",
+          "completed",
+          "stopped",
+        ]
+        const { status } = req.body
+        if (!validStatuses.includes(status)) {
+          return res.status(400).json({ message: "Invalid status" })
+        }
+
+        const { data, error } = await supabase
+          .from("user_shows")
+          .update({ status, updated_at: new Date().toISOString() })
+          .eq("user_id", req.userId!)
+          .eq("show_id", showId)
+          .select()
+          .single()
+
+        if (error) {
+          console.error("Update show status error:", error)
+          return res.status(500).json({ message: "Failed to update status" })
+        }
+
+        res.json(data)
+      } catch (error) {
+        console.error("Update show status error:", error)
+        res.status(500).json({ message: "Failed to update status" })
+      }
+    }
+  )
+
   // Remove show from user collection (soft delete: set status to "stopped")
   app.delete(
     "/api/user/shows/:showId",
@@ -627,6 +675,27 @@ export async function registerRoutes(app: Express): Promise<Server> {
         res.json(result)
       } catch (error) {
         console.error("Get want to watch shows error:", error)
+        res.status(500).json({ message: "Failed to get shows" })
+      }
+    }
+  )
+
+  app.get(
+    "/api/shows/stopped",
+    authMiddleware,
+    async (req: AuthRequest, res: Response) => {
+      try {
+        const page = parseInt(req.query.page as string) || 1
+        const limit = parseInt(req.query.limit as string) || 20
+        const search = (req.query.search as string) || undefined
+        const result = await getShowsWithProgress(req.userId!, "stopped", {
+          page,
+          limit,
+          search,
+        })
+        res.json(result)
+      } catch (error) {
+        console.error("Get stopped shows error:", error)
         res.status(500).json({ message: "Failed to get shows" })
       }
     }


### PR DESCRIPTION
## Summary
- `stopped` already existed as a status value used internally as a soft-delete marker (set via `DELETE /api/user/shows/:id`), but it had no Library tab, no explicit way to set it, and the DB CHECK constraint never actually allowed it. This makes it a real, first-class library status:
- **Server**: new `GET /api/shows/stopped` (mirrors the other status list endpoints), new `PATCH /api/user/shows/:showId` for explicit status changes, `stoppedShows` added to `/api/stats`, and `database-schema.sql`'s `user_shows.status` CHECK constraint now includes `'stopped'`.
- **Web**: new "Stopped" library tab/page/route with a live sidebar count; the show-detail "Remove from collection" action is renamed to **"Mark as Stopped"** since that's what it's always actually done (soft delete, progress kept).
- **Mobile**: new "Stopped" library tab with a live count; fixed a real bug where the show-detail status menu's "Stopped" option silently failed (it posted `status` to an endpoint that only read `initialStatus`, and could hit a duplicate-key error on an existing show) — now routed through the new PATCH endpoint; library/tab-count caches now refresh after any status change; added matching "you've stopped tracking this show" explainer copy to match web.

## Action required after merge
The live Supabase database's CHECK constraint on `user_shows.status` needs to be updated by hand (no migrations tooling in this repo — `database-schema.sql` only affects fresh installs):

```sql
ALTER TABLE user_shows DROP CONSTRAINT user_shows_status_check;
ALTER TABLE user_shows ADD CONSTRAINT user_shows_status_check
  CHECK (status IN ('want_to_watch', 'watching', 'completed', 'caught_up', 'stopped'));
```

## Test plan
- [x] `npm run check` (web/server) — passes
- [x] `apps/mobile && npm run check` — passes
- [x] `npx vite build` — succeeds
- [ ] Manual click-through wasn't possible in the dev sandbox (no Supabase/Auth0/TMDB credentials); please smoke-test marking a show as stopped and confirming it shows up in the new Stopped tab on both web and mobile, and that watching an episode moves it back out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)