### PR TITLE
Validate episode air dates before marking watched, fix stats determinism

### DIFF
--- a/apps/mobile/app/shows/[id].tsx
+++ b/apps/mobile/app/shows/[id].tsx
@@ -5,6 +5,7 @@ import {
   StyleSheet,
   TouchableOpacity,
   ImageBackground,
+  Alert,
 } from "react-native"
 import { Text, Menu, ActivityIndicator } from "react-native-paper"
 import { LinearGradient } from "expo-linear-gradient"
@@ -18,6 +19,7 @@ import type {
   TMDBSeason,
   EpisodeProgress,
 } from "@showtracker/shared"
+import { isEpisodeAired } from "@showtracker/shared"
 import {
   useAppTheme,
   STATUS_COLORS,
@@ -146,6 +148,7 @@ export default function ShowDetailScreen() {
         watched,
       }),
     onSuccess: invalidateShow,
+    onError: () => Alert.alert("Error", "This episode hasn't aired yet."),
   })
 
   const markAllSeason = useMutation({
@@ -522,13 +525,18 @@ export default function ShowDetailScreen() {
             const watched = watchedSet.has(
               `${ep.season_number}x${ep.episode_number}`
             )
+            const hasAired = isEpisodeAired(ep.air_date)
             const isCurrentSp = currentStatus
               ? STATUS_COLORS[currentStatus]
               : STATUS_COLORS.watching
             return (
               <TouchableOpacity
                 key={`${ep.season_number}x${ep.episode_number}`}
-                style={[styles.episodeRow, { borderBottomColor: t.border }]}
+                style={[
+                  styles.episodeRow,
+                  { borderBottomColor: t.border },
+                  !watched && !hasAired && { opacity: 0.4 },
+                ]}
                 onPress={() =>
                   toggleEpisode.mutate({
                     seasonNumber: ep.season_number,
@@ -536,7 +544,7 @@ export default function ShowDetailScreen() {
                     watched: !watched,
                   })
                 }
-                disabled={toggleEpisode.isPending}
+                disabled={toggleEpisode.isPending || (!watched && !hasAired)}
                 activeOpacity={0.7}
               >
                 <View

--- a/apps/web/src/pages/show-detail.tsx
+++ b/apps/web/src/pages/show-detail.tsx
@@ -19,7 +19,7 @@ import { StatusBadge } from "@/components/status-badge"
 import { statusPalette, type StatusKey } from "@/lib/status"
 import { useTheme } from "@/components/theme-provider"
 import { Star, Check, ChevronLeft } from "lucide-react"
-import { ShowWithProgress, TMDBSeason } from "@shared/schema"
+import { ShowWithProgress, TMDBSeason, isEpisodeAired } from "@shared/schema"
 import { queryClient, apiRequest } from "@/lib/queryClient"
 import { useToast } from "@/hooks/use-toast"
 import {
@@ -119,6 +119,12 @@ export default function ShowDetail() {
       })
     },
     onSuccess: invalidateAll,
+    onError: () =>
+      toast({
+        title: "Error",
+        description: "This episode hasn't aired yet.",
+        variant: "destructive",
+      }),
   })
 
   const addShowMutation = useMutation({
@@ -207,10 +213,7 @@ export default function ShowDetail() {
         wp.season === seasonNumber && wp.episode === episodeNumber && wp.watched
     )
 
-  const hasEpisodeAired = (airDate: string | null) => {
-    if (!airDate) return false
-    return new Date(airDate) <= new Date()
-  }
+  const hasEpisodeAired = (airDate: string | null) => isEpisodeAired(airDate)
 
   const getSeasonProgress = (seasonNumber: number) => {
     const season = seasons?.find((s) => s.season_number === seasonNumber)

--- a/database-schema.sql
+++ b/database-schema.sql
@@ -136,3 +136,30 @@ CREATE INDEX IF NOT EXISTS idx_device_tokens_user_id ON device_tokens(user_id);
 
 ALTER TABLE device_tokens ENABLE ROW LEVEL SECURITY;
 CREATE POLICY "Public access to device_tokens" ON device_tokens FOR ALL USING (true);
+
+-- Counts a user's watched episodes that have aired, restricted to a set of shows.
+-- Does the watch_progress/episodes join and count in the DB so results aren't
+-- subject to PostgREST's default row cap on the underlying tables.
+CREATE OR REPLACE FUNCTION count_aired_watched_episodes(
+  p_user_id TEXT,
+  p_show_ids INTEGER[],
+  p_now TEXT
+)
+RETURNS INTEGER
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT COUNT(*)::INTEGER
+  FROM watch_progress wp
+  JOIN episodes e
+    ON e.show_id = wp.show_id
+   AND e.season_number = wp.season_number
+   AND e.episode_number = wp.episode_number
+  WHERE wp.user_id = p_user_id
+    AND wp.watched = true
+    AND wp.show_id = ANY(p_show_ids)
+    AND e.air_date IS NOT NULL
+    AND e.air_date <= p_now
+$$;
+
+GRANT EXECUTE ON FUNCTION count_aired_watched_episodes(TEXT, INTEGER[], TEXT) TO anon, authenticated;

--- a/packages/shared/episode-utils.ts
+++ b/packages/shared/episode-utils.ts
@@ -1,0 +1,7 @@
+export function isEpisodeAired(
+  airDate: string | null | undefined,
+  now: Date = new Date()
+): boolean {
+  if (!airDate) return false
+  return new Date(airDate) <= now
+}

--- a/packages/shared/schema.ts
+++ b/packages/shared/schema.ts
@@ -10,6 +10,8 @@ import {
 import { createInsertSchema } from "drizzle-zod"
 import { z } from "zod"
 
+export * from "./episode-utils"
+
 // Users table
 export const users = pgTable("users", {
   id: text("id")

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -5,6 +5,7 @@ import { supabase } from "./lib/supabase"
 import { searchTVShows, getTVShowDetails, getTVShowSeason } from "./lib/tmdb"
 import { getUserFromAccessToken, getSubFromToken } from "./lib/auth0"
 import { scheduleBackgroundTask } from "./lib/background-task"
+import { isEpisodeAired } from "../packages/shared/episode-utils"
 
 interface AuthRequest extends Request {
   userId?: string
@@ -339,33 +340,15 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
         let episodesWatched = 0
         if (activeShowIds.length > 0) {
-          const { data: watchedRows } = await supabase
-            .from("watch_progress")
-            .select("show_id, season_number, episode_number")
-            .eq("user_id", req.userId)
-            .eq("watched", true)
-            .in("show_id", activeShowIds)
-
-          if (watchedRows && watchedRows.length > 0) {
-            const now = new Date().toISOString()
-            const { data: airedEpisodes } = await supabase
-              .from("episodes")
-              .select("show_id, season_number, episode_number")
-              .in("show_id", activeShowIds)
-              .lte("air_date", now)
-              .not("air_date", "is", null)
-
-            const airedKeys = new Set(
-              (airedEpisodes || []).map(
-                (e) => `${e.show_id}-${e.season_number}-${e.episode_number}`
-              )
-            )
-            episodesWatched = watchedRows.filter((w) =>
-              airedKeys.has(
-                `${w.show_id}-${w.season_number}-${w.episode_number}`
-              )
-            ).length
-          }
+          const { data: count } = await supabase.rpc(
+            "count_aired_watched_episodes",
+            {
+              p_user_id: req.userId,
+              p_show_ids: activeShowIds,
+              p_now: new Date().toISOString(),
+            }
+          )
+          episodesWatched = count || 0
         }
 
         const stats = {
@@ -926,6 +909,15 @@ export async function registerRoutes(app: Express): Promise<Server> {
         const { season, episode, watched } = req.body
         const showId = parseInt(id)
 
+        if (watched) {
+          const airDate = await getEpisodeAirDate(showId, season, episode)
+          if (!isEpisodeAired(airDate)) {
+            return res
+              .status(400)
+              .json({ message: "This episode hasn't aired yet." })
+          }
+        }
+
         const { error } = await supabase.from("watch_progress").upsert(
           {
             user_id: req.userId,
@@ -1039,39 +1031,62 @@ export async function registerRoutes(app: Express): Promise<Server> {
       try {
         const { id } = req.params
         const { episodes } = req.body
+        const showId = parseInt(id)
 
         if (!Array.isArray(episodes) || episodes.length === 0) {
           return res.status(400).json({ message: "Episodes array is required" })
         }
 
-        // Create progress records for all episodes
-        const progressRecords = episodes.map((ep: any) => ({
+        // Drop watched=true entries for episodes that haven't aired; unwatching
+        // is always allowed. Only fetch air dates for the entries that need one.
+        const validEpisodes = await Promise.all(
+          episodes.map(async (ep: any) => {
+            if (!ep.watched) return ep
+            const airDate = await getEpisodeAirDate(
+              showId,
+              ep.season,
+              ep.episode
+            )
+            return isEpisodeAired(airDate) ? ep : null
+          })
+        ).then((results) => results.filter((ep): ep is any => ep !== null))
+
+        // Create progress records for the valid episodes
+        const progressRecords = validEpisodes.map((ep: any) => ({
           user_id: req.userId,
-          show_id: parseInt(id),
+          show_id: showId,
           season_number: ep.season,
           episode_number: ep.episode,
           watched: ep.watched,
           watched_at: ep.watched ? new Date().toISOString() : null,
         }))
 
-        // Batch upsert all episodes (specify composite key for conflict resolution)
-        const { error } = await supabase
-          .from("watch_progress")
-          .upsert(progressRecords, {
-            onConflict: "user_id,show_id,season_number,episode_number",
-          })
+        if (progressRecords.length > 0) {
+          // Batch upsert all episodes (specify composite key for conflict resolution)
+          const { error } = await supabase
+            .from("watch_progress")
+            .upsert(progressRecords, {
+              onConflict: "user_id,show_id,season_number,episode_number",
+            })
 
-        if (error) {
-          console.error("Bulk progress update error:", error)
-          return res.status(500).json({ message: "Failed to update progress" })
+          if (error) {
+            console.error("Bulk progress update error:", error)
+            return res
+              .status(500)
+              .json({ message: "Failed to update progress" })
+          }
         }
 
         // Update inferred status in background (don't wait)
-        updateInferredStatus(req.userId!, parseInt(id)).catch((err) =>
+        updateInferredStatus(req.userId!, showId).catch((err) =>
           console.error("Background status update failed:", err)
         )
 
-        res.json({ success: true, count: episodes.length })
+        res.json({
+          success: true,
+          count: progressRecords.length,
+          skipped: episodes.length - progressRecords.length,
+        })
       } catch (error) {
         console.error("Bulk update progress error:", error)
         res.status(500).json({ message: "Failed to update progress" })
@@ -1676,6 +1691,41 @@ async function markShowEpisodesWatched(
   } catch (error) {
     console.error(`Error in markShowEpisodesWatched:`, error)
     throw error
+  }
+}
+
+// Returns a specific episode's air date, refreshing that season from TMDB if
+// it's missing from the cache (handles shows whose cache is stale/partial,
+// which ensureEpisodesCached's whole-show check won't catch). Returns null if
+// the episode can't be found even after a live check.
+async function getEpisodeAirDate(
+  showId: number,
+  seasonNumber: number,
+  episodeNumber: number
+): Promise<string | null> {
+  const { data: cached } = await supabase
+    .from("episodes")
+    .select("air_date")
+    .eq("show_id", showId)
+    .eq("season_number", seasonNumber)
+    .eq("episode_number", episodeNumber)
+    .maybeSingle()
+
+  if (cached) return cached.air_date
+
+  try {
+    const season = await getTVShowSeason(showId, seasonNumber)
+    await cacheEpisodesInDatabase(showId, [season])
+    const ep = (season.episodes || []).find(
+      (e: any) => e.episode_number === episodeNumber
+    )
+    return ep?.air_date ?? null
+  } catch (err) {
+    console.error(
+      `Failed to refresh season ${seasonNumber} for show ${showId}:`,
+      err
+    )
+    return null
   }
 }
 


### PR DESCRIPTION
## Summary
- `GET /api/stats` computed `episodesWatched` by pulling raw rows from `watch_progress` and `episodes` into Node and intersecting them in JS. Both queries were unbounded, so Supabase's default 1000-row cap silently truncated them for accounts with a lot of history — the count wasn't just wrong, it flapped between requests since Postgres doesn't guarantee which rows land in an un-ordered `LIMIT`. Replaced it with a Postgres function (`count_aired_watched_episodes`, added to `database-schema.sql`) that does the join and count server-side, called via `.rpc(...)`.
- Digging into why watched episodes could show up as "not aired," found two write endpoints — `POST /api/shows/:id/progress` (single toggle) and `POST /api/shows/:id/progress/bulk` — had **zero server-side validation** that an episode had actually aired before letting a client mark it watched; they trusted the client entirely (unlike `/season/:seasonNumber/mark-all`, which already validated correctly against live TMDB data). Mobile had no client-side guard at all for this, unlike web.
- Added a shared `isEpisodeAired` util (`packages/shared/episode-utils.ts`) and enforced it server-side: a new `getEpisodeAirDate` helper checks the `episodes` cache and self-heals by refreshing just that season from TMDB on a miss (handles stale/partial caches, not just empty ones). The single-toggle endpoint now rejects marking an unaired episode watched with a 400; the bulk endpoint silently filters unaired entries out of the batch, matching `/mark-all`'s existing convention, and reports how many were applied vs. skipped.
- Web and mobile both now consume the shared `isEpisodeAired` util (dedupes a previously-inline copy on web, adds the missing client-side guard on mobile), and both toggle mutations now surface a "hasn't aired yet" error instead of failing silently.
- Ran a one-time audit of the account's ~5,900 watched episodes against live TMDB data (not committed — a scratch script) to backfill the `episodes` cache: 747 rows were legitimately-watched episodes missing from our cache (now fixed), leaving 5 true anomalies (one show with no TMDB-recorded air dates for a handful of episodes — a TMDB data gap, not a bug) which were deliberately left untouched.

## Action required after merge
None — the `count_aired_watched_episodes` SQL function has already been applied by hand to the live Supabase database (this repo has no migration tooling; `database-schema.sql` only affects fresh installs, same as prior schema changes).

## Test plan
- [x] `npm run check` (root: server/web/packages) — passes
- [x] `apps/mobile && npm run check` — passes
- [x] `eslint` on all changed files — clean (pre-existing CRLF/`any` warnings in untouched code left alone)
- [x] Verified against the live database: confirmed the prior unbounded queries were truncating at 1000 rows and producing a non-deterministic count; confirmed the new RPC returns a stable, correct count after backfill (5,310 aired-and-watched episodes for active shows)
- [ ] Manual click-through on web/mobile (toggling an aired vs. unaired episode, bulk "mark previous episodes") — pending user verification, not done in this sandbox (no way to drive the full logged-in UI here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)